### PR TITLE
Manage NodeJS binary at runtime

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +693,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +785,11 @@ name = "cc"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+dependencies = [
+ "jobserver",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "cesu8"
@@ -812,6 +849,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -904,6 +951,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "convert_case"
@@ -1156,6 +1209,12 @@ dependencies = [
  "redox_syscall 0.1.57",
  "winapi",
 ]
+
+[[package]]
+name = "deflate64"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "der"
@@ -2592,6 +2651,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2710,6 +2778,15 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "jpeg-decoder"
@@ -2888,6 +2965,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2909,6 +2992,16 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
 ]
 
 [[package]]
@@ -3626,6 +3719,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3874,17 +3977,20 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "command-group",
+ "flate2",
  "log",
  "prost 0.13.1",
  "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
+ "tar",
  "tauri",
  "tauri-plugin-shell",
  "tokio",
  "tonic 0.12.1",
  "tonic-build",
+ "zip 2.1.5",
 ]
 
 [[package]]
@@ -5919,7 +6025,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.52.0",
- "zip",
+ "zip 1.1.4",
 ]
 
 [[package]]
@@ -7567,6 +7673,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "zip"
@@ -7581,6 +7701,77 @@ dependencies = [
  "indexmap 2.2.6",
  "num_enum 0.7.2",
  "thiserror",
+]
+
+[[package]]
+name = "zip"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b895748a3ebcb69b9d38dcfdf21760859a4b0d0b0015277640c2ef4c69640e6f"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "hmac",
+ "indexmap 2.2.6",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror",
+ "time",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.12+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/src-tauri/tauri-plugin-plugin-runtime/Cargo.toml
+++ b/src-tauri/tauri-plugin-plugin-runtime/Cargo.toml
@@ -17,5 +17,12 @@ tauri-plugin-shell = "2.0.0-beta"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "process"] }
 tonic = "0.12.1"
 
+[target.'cfg(unix)'.dependencies]
+flate2 = "1.0.28"
+tar = "0.4.40"
+
+[target.'cfg(windows)'.dependencies]
+zip = "2.1.3"
+
 [build-dependencies]
 tonic-build = "0.12.1"

--- a/src-tauri/tauri-plugin-plugin-runtime/src/archive.rs
+++ b/src-tauri/tauri-plugin-plugin-runtime/src/archive.rs
@@ -1,0 +1,110 @@
+// FROM: https://github.com/beeequeue/nvm-rust
+
+#[cfg(unix)]
+use std::fs::remove_dir_all;
+#[cfg(windows)]
+use std::fs::File;
+#[cfg(windows)]
+use std::io::copy;
+#[cfg(unix)]
+use std::path::PathBuf;
+use std::{fs::create_dir_all, io::Cursor, path::Path};
+
+use anyhow::Result;
+#[cfg(unix)]
+use flate2::read::GzDecoder;
+use log::info;
+#[cfg(unix)]
+use tar::{Archive, Unpacked};
+#[cfg(target_os = "windows")]
+use zip::ZipArchive;
+
+#[cfg(target_os = "windows")]
+pub fn extract_archive(bytes: Vec<u8>, path: &Path) -> Result<()> {
+    let reader = Cursor::new(bytes);
+    let mut archive = ZipArchive::new(reader).unwrap();
+
+    for i in 0..archive.len() {
+        let mut item = archive.by_index(i).unwrap();
+        let file_path = item.mangled_name();
+        let file_path = file_path.to_string_lossy();
+
+        let mut new_path = path.to_owned();
+        if let Some(index) = file_path.find('\\') {
+            new_path.push(&file_path[index + 1..]);
+        }
+
+        if item.is_dir() && !new_path.exists() {
+            create_dir_all(&new_path)
+                .unwrap_or_else(|_| panic!("Could not create new folder: {new_path:?}"));
+        }
+
+        if item.is_file() {
+            let mut file = File::create(&*new_path)?;
+            copy(&mut item, &mut file).unwrap_or_else(|_| panic!("Couldn't write to {new_path:?}"));
+        }
+    }
+
+    info!(
+        "Extracted to {}",
+        // Have to remove \\?\ prefix 🤮
+        path.to_str()
+            .unwrap()
+            .strip_prefix("\\\\?\\")
+            .unwrap_or_else(|| path.to_str().unwrap())
+    );
+
+    Ok(())
+}
+
+#[cfg(unix)]
+pub fn extract_archive(bytes: Vec<u8>, path: &Path) -> Result<()> {
+    let reader = Cursor::new(bytes);
+    let tar = GzDecoder::new(reader);
+    let mut archive = Archive::new(tar);
+
+    let version_dir_path = path.to_owned();
+    create_dir_all(&version_dir_path).unwrap();
+
+    let result = archive
+        .entries()
+        .map_err(anyhow::Error::from)?
+        .filter_map(|e| e.ok())
+        .map(|mut entry| -> Result<Unpacked> {
+            let file_path = entry.path()?;
+            let file_path = file_path.to_str().unwrap();
+
+            let new_path: PathBuf = if let Some(index) = file_path.find('/') {
+                path.to_owned().join(&file_path[index + 1..])
+            } else {
+                // This happens if it's the root index, the base folder
+                path.to_owned()
+            };
+
+            entry.set_preserve_permissions(false);
+            entry.unpack(&new_path).map_err(anyhow::Error::from)
+        });
+
+    let errors: Vec<anyhow::Error> = result
+        .into_iter()
+        .filter(|result| result.is_err())
+        .map(|result| result.unwrap_err())
+        .collect();
+
+    if !errors.is_empty() {
+        remove_dir_all(version_dir_path).expect("Couldn't clean up version.");
+
+        return Err(anyhow::anyhow!(
+            "Failed to extract all files:\n{:?}",
+            errors
+                .into_iter()
+                .map(|err| err.to_string())
+                .collect::<Vec<String>>()
+                .join("/n")
+        ));
+    }
+
+    info!("Extracted to {version_dir_path:?}");
+
+    Ok(())
+}

--- a/src-tauri/tauri-plugin-plugin-runtime/src/lib.rs
+++ b/src-tauri/tauri-plugin-plugin-runtime/src/lib.rs
@@ -1,11 +1,13 @@
 extern crate core;
 
 use log::info;
-use crate::manager::PluginManager;
 use tauri::plugin::{Builder, TauriPlugin};
 use tauri::{Manager, RunEvent, Runtime, State};
 use tokio::sync::Mutex;
 
+use crate::manager::PluginManager;
+
+mod archive;
 pub mod manager;
 mod nodejs;
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,8 +41,7 @@
     "active": true,
     "category": "DeveloperTool",
     "externalBin": [
-      "vendored/protoc/yaakprotoc",
-      "vendored/node/yaaknode"
+      "vendored/protoc/yaakprotoc"
     ],
     "icon": [
       "icons/release/32x32.png",


### PR DESCRIPTION
This PR changes the NodeJS dependency from a Tauri Sidecar to self-managed binary. There is some Rust code to download and extract the Node binary into the correct place.

The management of this download is tricky because I haven't been able to figure out a way to lazily set a mutable global within Tauri state.