### PR TITLE
Use padding for Basic auth

### DIFF
--- a/src-tauri/src/http_request.rs
+++ b/src-tauri/src/http_request.rs
@@ -204,7 +204,7 @@ pub async fn send_http_request<R: Runtime>(
                 .unwrap_or_default();
 
             let auth = format!("{username}:{password}");
-            let encoded = base64::engine::general_purpose::STANDARD_NO_PAD.encode(auth);
+            let encoded = base64::engine::general_purpose::STANDARD.encode(auth);
             headers.insert(
                 "Authorization",
                 HeaderValue::from_str(&format!("Basic {}", encoded)).unwrap(),


### PR DESCRIPTION
Hi,

while trying Yaak, I have noticed that some requests using `Basic` auth does not work with the API I'm using. After debugging, I have found out that Yaak currently sends base64-encoded `Authorization` header without padding, which some APIs strictly require.

This change enables the padding for `Basic` auth, which aligns it with Insomnia (and Node.js "base64" encoding).