### PR TITLE
Namespaced template functions

### DIFF
--- a/src-web/components/core/Editor/Editor.css
+++ b/src-web/components/core/Editor/Editor.css
@@ -242,6 +242,11 @@
       @apply text-primary;
     }
 
+    &.cm-completionIcon-namespace::after {
+      content: 'n' !important;
+      @apply text-warning;
+    }
+
     &.cm-completionIcon-constant::after {
       content: 'c' !important;
       @apply text-notice;
@@ -265,10 +270,6 @@
 
     &.cm-completionIcon-method::after {
       content: 'm' !important;
-    }
-
-    &.cm-completionIcon-namespace::after {
-      content: 'n' !important;
     }
 
     &.cm-completionIcon-property::after {

--- a/src-web/components/core/Editor/twig/completion.ts
+++ b/src-web/components/core/Editor/twig/completion.ts
@@ -38,7 +38,6 @@ const MIN_MATCH_NAME = 1;
 export function twigCompletion({ options }: TwigCompletionConfig) {
   return function completions(context: CompletionContext) {
     const toStartOfName = context.matchBefore(/[\w_.]*/);
-    const toStartOfNamespacedName = context.matchBefore(/[\w_.]*/);
     const toStartOfVariable = context.matchBefore(/\$\{?\[?\s*[\w_]*/);
     const toMatch = toStartOfVariable ?? toStartOfName ?? null;
 
@@ -58,7 +57,7 @@ export function twigCompletion({ options }: TwigCompletionConfig) {
 
     const completions: Completion[] = options
       .map((o): Completion => {
-        const matchSegments = toStartOfNamespacedName!.text.split('.');
+        const matchSegments = toStartOfName!.text.split('.');
         const optionSegments = o.name.split('.');
 
         // If not on the last segment, only complete the namespace

--- a/src-web/components/core/Editor/twig/completion.ts
+++ b/src-web/components/core/Editor/twig/completion.ts
@@ -58,17 +58,8 @@ export function twigCompletion({ options }: TwigCompletionConfig) {
 
     const completions: Completion[] = options
       .map((o): Completion => {
-        const optionSegments = o.name.split('.');
         const matchSegments = toStartOfNamespacedName!.text.split('.');
-        // const prefix = toStartOfNamespacedName!.text
-        //   .split('.')
-        //   .slice(0, matchSegments.length)
-        //   .join('.');
-
-        // // Remove anything that doesn't start with the prefixed text
-        // if (!o.name.startsWith(prefix)) {
-        //   return null;
-        // }
+        const optionSegments = o.name.split('.');
 
         // If not on the last segment, only complete the namespace
         if (matchSegments.length < optionSegments.length) {

--- a/src-web/components/core/Editor/twig/templateTags.ts
+++ b/src-web/components/core/Editor/twig/templateTags.ts
@@ -9,7 +9,11 @@ import type { TwigCompletionOption } from './completion';
 class PathPlaceholderWidget extends WidgetType {
   readonly #clickListenerCallback: () => void;
 
-  constructor(readonly rawText: string, readonly startPos: number, readonly onClick: () => void) {
+  constructor(
+    readonly rawText: string,
+    readonly startPos: number,
+    readonly onClick: () => void,
+  ) {
     super();
     this.#clickListenerCallback = () => {
       this.onClick?.();
@@ -68,10 +72,10 @@ class TemplateTagWidget extends WidgetType {
       this.option.invalid
         ? 'x-theme-templateTag--danger'
         : this.option.type === 'variable'
-        ? 'x-theme-templateTag--primary'
-        : 'x-theme-templateTag--info'
+          ? 'x-theme-templateTag--primary'
+          : 'x-theme-templateTag--info'
     }`;
-    elt.title = this.option.invalid ? 'Not Found' : this.option.value ?? '';
+    elt.title = this.option.invalid ? 'Not Found' : (this.option.value ?? '');
     elt.setAttribute('data-tag-type', this.option.type);
     elt.textContent =
       this.option.type === 'variable'
@@ -134,7 +138,7 @@ function templateTags(
 
           // TODO: Search `node.tree` instead of using Regex here
           const inner = rawTag.replace(/^\$\{\[\s*/, '').replace(/\s*]}$/, '');
-          let name = inner.match(/(\w+)[(]/)?.[1] ?? inner;
+          let name = inner.match(/([\w.]+)[(]/)?.[1] ?? inner;
 
           // The beta named the function `Response` but was changed in stable.
           // Keep this here for a while because there's no easy way to migrate

--- a/src-web/hooks/useRenderTemplate.ts
+++ b/src-web/hooks/useRenderTemplate.ts
@@ -8,6 +8,7 @@ export function useRenderTemplate(template: string) {
   const environmentId = useActiveEnvironment()[0]?.id ?? null;
   return useQuery<string>({
     placeholderData: (prev) => prev, // Keep previous data on refetch
+    refetchOnWindowFocus: false,
     queryKey: ['render_template', template],
     queryFn: () => renderTemplate({ template, workspaceId, environmentId }),
   });


### PR DESCRIPTION
This PR adds support for template tags with multi-level APIs like Faker (eg. `faker.animal.dog()`.

- [x] Update template parser to handle namespaced function names
- [x] Update Codemirror completion logic to handle namespace segments


https://github.com/user-attachments/assets/38eb9c79-1d84-4ed2-ad82-68eacab2c63d

