### PR TITLE
Improved querystring import on paste

### DIFF
--- a/src-web/components/RequestPane.tsx
+++ b/src-web/components/RequestPane.tsx
@@ -323,10 +323,11 @@ export const RequestPane = memo(function RequestPane({
             url={activeRequest.url}
             method={activeRequest.method}
             placeholder="https://example.com"
-            onPaste={(text) => {
+            onPasteOverwrite={(text) => {
               if (text.startsWith('curl ')) {
                 importCurl.mutate({ overwriteRequestId: activeRequestId, command: text });
               } else {
+                // Only import query if pasted text contains entire querystring
                 importQuerystring.mutate(text);
               }
             }}

--- a/src-web/components/UrlBar.tsx
+++ b/src-web/components/UrlBar.tsx
@@ -17,6 +17,7 @@ type Props = Pick<HttpRequest, 'url'> & {
   onSend: () => void;
   onUrlChange: (url: string) => void;
   onPaste?: (v: string) => void;
+  onPasteOverwrite?: (v: string) => void;
   onCancel: () => void;
   submitIcon?: IconProps['icon'] | null;
   onMethodChange?: (method: string) => void;
@@ -37,6 +38,7 @@ export const UrlBar = memo(function UrlBar({
   onCancel,
   onMethodChange,
   onPaste,
+  onPasteOverwrite,
   submitIcon = 'send_horizontal',
   autocomplete,
   rightSlot,
@@ -77,6 +79,7 @@ export const UrlBar = memo(function UrlBar({
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
         onPaste={onPaste}
+        onPasteOverwrite={onPasteOverwrite}
         onChange={onUrlChange}
         defaultValue={url}
         placeholder={placeholder}

--- a/src-web/components/core/Editor/Editor.tsx
+++ b/src-web/components/core/Editor/Editor.tsx
@@ -55,6 +55,7 @@ export interface EditorProps {
   useTemplating?: boolean;
   onChange?: (value: string) => void;
   onPaste?: (value: string) => void;
+  onPasteOverwrite?: (value: string) => void;
   onFocus?: () => void;
   onBlur?: () => void;
   onKeyDown?: (e: KeyboardEvent) => void;
@@ -83,6 +84,7 @@ export const Editor = forwardRef<EditorView | undefined, EditorProps>(function E
     forceUpdateKey,
     onChange,
     onPaste,
+    onPasteOverwrite,
     onFocus,
     onBlur,
     onKeyDown,
@@ -120,6 +122,12 @@ export const Editor = forwardRef<EditorView | undefined, EditorProps>(function E
   useEffect(() => {
     handlePaste.current = onPaste;
   }, [onPaste]);
+
+  // Use ref so we can update the handler without re-initializing the editor
+  const handlePasteOverwrite = useRef<EditorProps['onPasteOverwrite']>(onPaste);
+  useEffect(() => {
+    handlePasteOverwrite.current = onPasteOverwrite;
+  }, [onPasteOverwrite]);
 
   // Use ref so we can update the handler without re-initializing the editor
   const handleFocus = useRef<EditorProps['onFocus']>(onFocus);
@@ -303,6 +311,7 @@ export const Editor = forwardRef<EditorView | undefined, EditorProps>(function E
               singleLine,
               onChange: handleChange,
               onPaste: handlePaste,
+              onPasteOverwrite: handlePasteOverwrite,
               onFocus: handleFocus,
               onBlur: handleBlur,
               onKeyDown: handleKeyDown,
@@ -420,6 +429,7 @@ function getExtensions({
   singleLine,
   onChange,
   onPaste,
+  onPasteOverwrite,
   onFocus,
   onBlur,
   onKeyDown,
@@ -427,6 +437,7 @@ function getExtensions({
   container: HTMLDivElement | null;
   onChange: MutableRefObject<EditorProps['onChange']>;
   onPaste: MutableRefObject<EditorProps['onPaste']>;
+  onPasteOverwrite: MutableRefObject<EditorProps['onPasteOverwrite']>;
   onFocus: MutableRefObject<EditorProps['onFocus']>;
   onBlur: MutableRefObject<EditorProps['onBlur']>;
   onKeyDown: MutableRefObject<EditorProps['onKeyDown']>;
@@ -449,8 +460,12 @@ function getExtensions({
       keydown: (e) => {
         onKeyDown.current?.(e);
       },
-      paste: (e) => {
-        onPaste.current?.(e.clipboardData?.getData('text/plain') ?? '');
+      paste: (e, v) => {
+        const textData = e.clipboardData?.getData('text/plain') ?? '';
+        onPaste.current?.(textData);
+        if (v.state.selection.main.from === 0 && v.state.selection.main.to === v.state.doc.length) {
+          onPasteOverwrite.current?.(textData);
+        }
       },
     }),
     tooltips({ parent }),

--- a/src-web/components/core/Input.tsx
+++ b/src-web/components/core/Input.tsx
@@ -35,6 +35,7 @@ export type InputProps = Omit<
     onFocus?: () => void;
     onBlur?: () => void;
     onPaste?: (value: string) => void;
+    onPasteOverwrite?: (value: string) => void;
     defaultValue?: string;
     leftSlot?: ReactNode;
     rightSlot?: ReactNode;
@@ -62,6 +63,7 @@ export const Input = forwardRef<EditorView | undefined, InputProps>(function Inp
     onChange,
     onFocus,
     onPaste,
+    onPasteOverwrite,
     placeholder,
     require,
     rightSlot,
@@ -179,6 +181,7 @@ export const Input = forwardRef<EditorView | undefined, InputProps>(function Inp
             placeholder={placeholder}
             onChange={handleChange}
             onPaste={onPaste}
+            onPasteOverwrite={onPasteOverwrite}
             className={editorClassName}
             onFocus={handleFocus}
             onBlur={handleBlur}

--- a/src-web/hooks/useImportQuerystring.ts
+++ b/src-web/hooks/useImportQuerystring.ts
@@ -32,12 +32,7 @@ export function useImportQuerystring(requestId: string) {
 
       const urlParameters: HttpUrlParameter[] = [];
       for (const newParam of additionalUrlParameters) {
-        const index = urlParameters.findIndex((p) => p.name === newParam.name);
-        if (index >= 0) {
-          urlParameters[index]!.value = decodeURIComponent(newParam.value);
-        } else {
-          urlParameters.push(newParam);
-        }
+        urlParameters.push(newParam);
       }
 
       await updateRequest.mutateAsync({

--- a/src-web/hooks/useImportQuerystring.ts
+++ b/src-web/hooks/useImportQuerystring.ts
@@ -30,7 +30,7 @@ export function useImportQuerystring(requestId: string) {
         }),
       );
 
-      const urlParameters: HttpUrlParameter[] = [...request.urlParameters];
+      const urlParameters: HttpUrlParameter[] = [];
       for (const newParam of additionalUrlParameters) {
         const index = urlParameters.findIndex((p) => p.name === newParam.name);
         if (index >= 0) {


### PR DESCRIPTION
This PR:

- Only imports querystring params if entire URL is selected (overwrite)
- Removes all existing params before populating new ones

Fixes #105 