### PR TITLE
Preserve invalid GraphQL variables 

### DIFF
--- a/src-web/components/GraphQLEditor.tsx
+++ b/src-web/components/GraphQLEditor.tsx
@@ -25,8 +25,10 @@ export function GraphQLEditor({ body, onChange, baseRequest, ...extraEditorProps
     // NOTE: This is how GraphQL used to be stored
     if ('text' in body) {
       const b = tryParseJson(body.text, {});
-      return { query: b.query ?? '', variables: JSON.stringify(b.variables ?? '', null, 2) };
+      const variables = JSON.stringify(b.variables ?? '', null, 2);
+      return { query: b.query ?? '', variables };
     }
+
     return { query: body.query ?? '', variables: body.variables ?? '' };
   });
 

--- a/src-web/components/RequestPane.tsx
+++ b/src-web/components/RequestPane.tsx
@@ -419,8 +419,8 @@ export const RequestPane = memo(function RequestPane({
                 <GraphQLEditor
                   forceUpdateKey={forceUpdateKey}
                   baseRequest={activeRequest}
-                  defaultValue={`${activeRequest.body?.text ?? ''}`}
-                  onChange={handleBodyTextChange}
+                  body={activeRequest.body}
+                  onChange={handleBodyChange}
                 />
               ) : activeRequest.bodyType === BODY_TYPE_FORM_URLENCODED ? (
                 <FormUrlencodedEditor


### PR DESCRIPTION
This PR changes to GraphQL body type to use a custom format, instead of serializing to `text: ".."` on every keystroke.

This change is so we can preserve invalid JSON in the variables editor. Some people may want to make some changes, switch requests, then switch back and continue editing. The current requirement to parse variables as valid JSON prevents the editor from saving and throws away changes when navigating away. It's also very possible that someone might want to actually send invalid JSON to test a GraphQL endpoint. This PR makes that happen.

- Change `HttpRequest.body` from `{text: String}` to `{variables: Records<string, string>, query: string}`
- Update `<GraphQLEditor/>` to use the new format
- Migrate `text` property to new format within `<GraphQLEditor/>`
  - Note: also allows converting JSON->GraphQL body type

Fixes #103