### PR TITLE
fix: oauth2 audience not sent

### DIFF
--- a/src-tauri/vendored/plugins/auth-oauth2/build/index.js
+++ b/src-tauri/vendored/plugins/auth-oauth2/build/index.js
@@ -57,7 +57,7 @@ async function getAccessToken(ctx, {
     ]
   };
   if (scope) httpRequest.body.form.push({ name: "scope", value: scope });
-  if (scope) httpRequest.body.form.push({ name: "audience", value: audience });
+  if (audience) httpRequest.body.form.push({ name: "audience", value: audience });
   if (credentialsInBody) {
     httpRequest.body.form.push({ name: "client_id", value: clientId });
     httpRequest.body.form.push({ name: "client_secret", value: clientSecret });


### PR DESCRIPTION
The OAuth2 audience was only getting sent if scope was set. I think this is unintentional, since scope is optional.