### PR TITLE
feat: Add cURL Import Option In Dropdown Menu

### DIFF
--- a/src-web/components/ImportCurlDialog.tsx
+++ b/src-web/components/ImportCurlDialog.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react';
+import { useImportCurl } from '../hooks/useImportCurl';
+import { Banner } from './core/Banner';
+import { Button } from './core/Button';
+import { Editor } from './core/Editor/LazyEditor';
+import { Icon } from './core/Icon';
+import { HStack, VStack } from './core/Stacks';
+
+interface Props {
+  hide: () => void;
+}
+
+const EXAMPLE_CURL = `curl https://api.example.com/users \\
+  -H 'Authorization: Bearer token123' \\
+  -H 'Content-Type: application/json' \\
+  -d '{"name": "John Doe"}'`;
+
+export function ImportCurlDialog({ hide }: Props) {
+  const [curlCommand, setCurlCommand] = useState<string>('');
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const { mutate: importCurl } = useImportCurl();
+
+  const handleImport = async () => {
+    if (!curlCommand.trim()) {
+      return;
+    }
+
+    // Basic validation
+    if (!curlCommand.trim().toLowerCase().startsWith('curl')) {
+      setError('Please paste a valid cURL command starting with "curl"');
+      return;
+    }
+
+    setError(null);
+    setIsLoading(true);
+    try {
+      await importCurl({ command: curlCommand });
+      hide();
+    } catch (error) {
+      console.error('Failed to import cURL:', error);
+      setError('Failed to import cURL command. Please check the format and try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <VStack space={4} className="h-full">
+      {/* Info Banner */}
+      <Banner color="info" className="text-sm">
+        <VStack space={1.5}>
+          <div className="flex items-start gap-2">
+            <Icon icon="info" className="mt-0.5 flex-shrink-0" />
+            <div>
+              <div className="font-medium mb-1">Paste your cURL command below</div>
+              <div className="text-text-subtle">
+                The command will be converted into a new HTTP request with all headers, body, and
+                parameters preserved.
+              </div>
+            </div>
+          </div>
+        </VStack>
+      </Banner>
+
+      {/* Editor Section */}
+      <VStack space={2} className="flex-1 min-h-0">
+        <div className="text-sm font-medium text-text">cURL Command</div>
+        <div className="flex-1 min-h-[280px] border border-border rounded-md overflow-hidden shadow-sm">
+          <Editor
+            heightMode="full"
+            hideGutter
+            language="text"
+            placeholder={EXAMPLE_CURL}
+            onChange={(value) => {
+              setCurlCommand(value);
+              if (error) setError(null);
+            }}
+            defaultValue={curlCommand}
+            stateKey="import-curl-dialog"
+          />
+        </div>
+      </VStack>
+
+      {/* Error Message */}
+      {error && (
+        <Banner color="danger" className="text-sm">
+          <div className="flex items-start gap-2">
+            <Icon icon="alert_triangle" className="mt-0.5 flex-shrink-0" />
+            <div>{error}</div>
+          </div>
+        </Banner>
+      )}
+
+      {/* Action Buttons */}
+      <HStack space={2} justifyContent="end" className="pt-2 border-t border-border-subtle">
+        <Button variant="border" onClick={hide} disabled={isLoading}>
+          Cancel
+        </Button>
+        <Button
+          color="primary"
+          onClick={handleImport}
+          disabled={!curlCommand.trim() || isLoading}
+          isLoading={isLoading}
+          leftSlot={!isLoading && <Icon icon="import" />}
+        >
+          {isLoading ? 'Importing...' : 'Import Request'}
+        </Button>
+      </HStack>
+    </VStack>
+  );
+}

--- a/src-web/components/ImportCurlDialog.tsx
+++ b/src-web/components/ImportCurlDialog.tsx
@@ -4,6 +4,7 @@ import { Banner } from './core/Banner';
 import { Button } from './core/Button';
 import { Editor } from './core/Editor/LazyEditor';
 import { Icon } from './core/Icon';
+import { PlainInput } from './core/PlainInput';
 import { HStack, VStack } from './core/Stacks';
 
 interface Props {
@@ -17,6 +18,7 @@ const EXAMPLE_CURL = `curl https://api.example.com/users \\
 
 export function ImportCurlDialog({ hide }: Props) {
   const [curlCommand, setCurlCommand] = useState<string>('');
+  const [requestName, setRequestName] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const { mutate: importCurl } = useImportCurl();
@@ -35,7 +37,7 @@ export function ImportCurlDialog({ hide }: Props) {
     setError(null);
     setIsLoading(true);
     try {
-      await importCurl({ command: curlCommand });
+      await importCurl({ command: curlCommand, name: requestName });
       hide();
     } catch (error) {
       console.error('Failed to import cURL:', error);
@@ -62,6 +64,18 @@ export function ImportCurlDialog({ hide }: Props) {
           </div>
         </VStack>
       </Banner>
+
+      {/* Request Name (Optional) */}
+      <VStack space={2}>
+        <div className="text-sm font-medium text-text">Name <span className="text-text-subtle font-normal">(optional)</span></div>
+        <PlainInput
+          label="Request Name"
+          hideLabel
+          placeholder="e.g., Get Users, Create Order"
+          defaultValue={requestName}
+          onChange={(value) => setRequestName(value)}
+        />
+      </VStack>
 
       {/* Editor Section */}
       <VStack space={2} className="flex-1 min-h-0">

--- a/src-web/hooks/useCreateDropdownItems.tsx
+++ b/src-web/hooks/useCreateDropdownItems.tsx
@@ -5,9 +5,7 @@ import { useMemo } from 'react';
 import { createFolder } from '../commands/commands';
 import type { DropdownItem } from '../components/core/Dropdown';
 import { Icon } from '../components/core/Icon';
-import { ImportCurlDialog } from '../components/ImportCurlDialog';
 import { createRequestAndNavigate } from '../lib/createRequestAndNavigate';
-import { showDialog } from '../lib/dialog';
 import { generateId } from '../lib/generateId';
 import { BODY_TYPE_GRAPHQL } from '../lib/model_util';
 import { activeRequestAtom } from './useActiveRequest';
@@ -65,17 +63,6 @@ export function getCreateDropdownItems({
         const id = await createRequestAndNavigate({ model: 'http_request', workspaceId, folderId });
         onCreate?.('http_request', id);
       },
-    },
-    {
-      label: 'cURL',
-      leftSlot: hideIcons ? undefined : <Icon icon="plus" />,
-      onSelect: () =>
-        showDialog({
-          id: 'import-curl',
-          title: 'Import cURL Command',
-          size: 'md',
-          render: ImportCurlDialog,
-        }),
     },
     {
       label: 'GraphQL',

--- a/src-web/hooks/useCreateDropdownItems.tsx
+++ b/src-web/hooks/useCreateDropdownItems.tsx
@@ -5,7 +5,9 @@ import { useMemo } from 'react';
 import { createFolder } from '../commands/commands';
 import type { DropdownItem } from '../components/core/Dropdown';
 import { Icon } from '../components/core/Icon';
+import { ImportCurlDialog } from '../components/ImportCurlDialog';
 import { createRequestAndNavigate } from '../lib/createRequestAndNavigate';
+import { showDialog } from '../lib/dialog';
 import { generateId } from '../lib/generateId';
 import { BODY_TYPE_GRAPHQL } from '../lib/model_util';
 import { activeRequestAtom } from './useActiveRequest';
@@ -63,6 +65,17 @@ export function getCreateDropdownItems({
         const id = await createRequestAndNavigate({ model: 'http_request', workspaceId, folderId });
         onCreate?.('http_request', id);
       },
+    },
+    {
+      label: 'cURL',
+      leftSlot: hideIcons ? undefined : <Icon icon="plus" />,
+      onSelect: () =>
+        showDialog({
+          id: 'import-curl',
+          title: 'Import cURL Command',
+          size: 'md',
+          render: ImportCurlDialog,
+        }),
     },
     {
       label: 'GraphQL',

--- a/src-web/hooks/useImportCurl.ts
+++ b/src-web/hooks/useImportCurl.ts
@@ -14,9 +14,11 @@ export function useImportCurl() {
     mutationFn: async ({
       overwriteRequestId,
       command,
+      name,
     }: {
       overwriteRequestId?: string;
       command: string;
+      name?: string;
     }) => {
       const workspaceId = jotaiStore.get(activeWorkspaceIdAtom);
       const importedRequest: HttpRequest = await invokeCmd('cmd_curl_to_request', {
@@ -24,10 +26,16 @@ export function useImportCurl() {
         workspaceId,
       });
 
+      // Apply custom name if provided
+      const requestToCreate = {
+        ...importedRequest,
+        name: name?.trim() || importedRequest.name,
+      };
+
       let verb: string;
       if (overwriteRequestId == null) {
         verb = 'Created';
-        await createRequestAndNavigate(importedRequest);
+        await createRequestAndNavigate(requestToCreate);
       } else {
         verb = 'Updated';
         await patchModelById(importedRequest.model, overwriteRequestId, (r: HttpRequest) => ({


### PR DESCRIPTION
### Problem
Users had to discover the cURL import feature by accident (pasting into URL bar or via Import Data dialog, atleast I discovered it by accident). This made it hard to find and use.

### Solution
Added a dedicated "cURL" option to the Create dropdown (Cmd+N) that opens a professional dialog for importing cURL commands.

feel free to close/ignore if unwanted

<img width="431" height="314" alt="image" src="https://github.com/user-attachments/assets/ca22bb27-013b-4980-bf34-5b57056037d7" />
<img width="801" height="551" alt="image" src="https://github.com/user-attachments/assets/479bf020-7766-4c19-b1c1-724923719cec" />
