### PR TITLE
feat: implement layered settings system for HTTP requests and folders

### DIFF
--- a/crates-tauri/yaak-app/src/lib.rs
+++ b/crates-tauri/yaak-app/src/lib.rs
@@ -233,7 +233,7 @@ async fn cmd_grpc_reflect<R: Runtime>(
             &uri,
             &proto_files.iter().map(|p| PathBuf::from_str(p).unwrap()).collect(),
             &metadata,
-            workspace.setting_validate_certificates,
+            workspace.setting_validate_certificates.unwrap_or(true),
             client_certificate,
             skip_cache.unwrap_or(false),
         )
@@ -327,7 +327,7 @@ async fn cmd_grpc_go<R: Runtime>(
             uri.as_str(),
             &proto_files.iter().map(|p| PathBuf::from_str(p).unwrap()).collect(),
             &metadata,
-            workspace.setting_validate_certificates,
+            workspace.setting_validate_certificates.unwrap_or(true),
             client_cert.clone(),
         )
         .await;

--- a/crates-tauri/yaak-app/src/ws_ext.rs
+++ b/crates-tauri/yaak-app/src/ws_ext.rs
@@ -355,7 +355,7 @@ pub async fn cmd_ws_connect<R: Runtime>(
             url.as_str(),
             headers,
             receive_tx,
-            workspace.setting_validate_certificates,
+            workspace.setting_validate_certificates.unwrap_or(true),
             client_cert,
         )
         .await

--- a/crates/yaak-models/migrations/20260109201041_layered_settings.sql
+++ b/crates/yaak-models/migrations/20260109201041_layered_settings.sql
@@ -1,0 +1,9 @@
+-- Add nullable settings columns to folders (NULL = inherit from parent)
+ALTER TABLE folders ADD COLUMN setting_request_timeout INTEGER DEFAULT NULL;
+ALTER TABLE folders ADD COLUMN setting_validate_certificates BOOLEAN DEFAULT NULL;
+ALTER TABLE folders ADD COLUMN setting_follow_redirects BOOLEAN DEFAULT NULL;
+
+-- Add nullable settings columns to http_requests (NULL = inherit from parent)
+ALTER TABLE http_requests ADD COLUMN setting_request_timeout INTEGER DEFAULT NULL;
+ALTER TABLE http_requests ADD COLUMN setting_validate_certificates BOOLEAN DEFAULT NULL;
+ALTER TABLE http_requests ADD COLUMN setting_follow_redirects BOOLEAN DEFAULT NULL;

--- a/crates/yaak-models/src/queries/workspaces.rs
+++ b/crates/yaak-models/src/queries/workspaces.rs
@@ -20,8 +20,8 @@ impl<'a> DbContext<'a> {
             workspaces.push(self.upsert_workspace(
                 &Workspace {
                     name: "Yaak".to_string(),
-                    setting_follow_redirects: true,
-                    setting_validate_certificates: true,
+                    setting_follow_redirects: Some(true),
+                    setting_validate_certificates: Some(true),
                     ..Default::default()
                 },
                 &UpdateSource::Background,


### PR DESCRIPTION
Add support for settings overrides at folder and HTTP request levels. Introduces nullable settings columns to database tables and implements resolution logic to merge workspace, folder, and request-level settings with proper precedence.