### PR TITLE
fix: Add username to the tokenStoreKey so the saved token is invalidated when the user changes in the environment

### DIFF
--- a/plugins/auth-oauth2/src/grants/password.ts
+++ b/plugins/auth-oauth2/src/grants/password.ts
@@ -32,6 +32,7 @@ export async function getPassword(
     clientId,
     accessTokenUrl,
     authorizationUrl: null,
+    username,
   };
   const token = await getOrRefreshAccessToken(ctx, tokenArgs, {
     accessTokenUrl,

--- a/plugins/auth-oauth2/src/index.ts
+++ b/plugins/auth-oauth2/src/index.ts
@@ -103,6 +103,7 @@ export const plugin: PluginDefinition = {
             authorizationUrl: stringArg(values, "authorizationUrl"),
             accessTokenUrl: stringArg(values, "accessTokenUrl"),
             clientId: stringArg(values, "clientId"),
+            username: usernameArg(values),
           };
           const token = await getToken(ctx, tokenArgs);
           if (token == null) {
@@ -128,6 +129,7 @@ export const plugin: PluginDefinition = {
             authorizationUrl: stringArg(values, "authorizationUrl"),
             accessTokenUrl: stringArg(values, "accessTokenUrl"),
             clientId: stringArg(values, "clientId"),
+            username: usernameArg(values),
           };
           if (await deleteToken(ctx, tokenArgs)) {
             await ctx.toast.show({
@@ -478,6 +480,7 @@ export const plugin: PluginDefinition = {
             authorizationUrl: stringArg(values, "authorizationUrl"),
             accessTokenUrl: stringArg(values, "accessTokenUrl"),
             clientId: stringArg(values, "clientId"),
+            username: usernameArg(values),
           };
           const token = await getToken(ctx, tokenArgs);
           if (token == null) {
@@ -607,6 +610,12 @@ function stringArgOrNull(
   const arg = values[name];
   if (arg == null || arg === "") return null;
   return `${arg}`;
+}
+
+/** Only the password grant stores its token under a username, so the others must not key by one */
+function usernameArg(values: Record<string, JsonPrimitive | undefined>): string | null {
+  const grantType = String(values.grantType ?? defaultGrantType);
+  return grantType === "password" ? stringArgOrNull(values, "username") : null;
 }
 
 function stringArg(values: Record<string, JsonPrimitive | undefined>, name: string): string {

--- a/plugins/auth-oauth2/src/store.ts
+++ b/plugins/auth-oauth2/src/store.ts
@@ -47,6 +47,7 @@ export interface TokenStoreArgs {
   clientId: string;
   accessTokenUrl: string | null;
   authorizationUrl: string | null;
+  username?: string | null;
 }
 
 /**
@@ -59,6 +60,7 @@ function tokenStoreKey(args: TokenStoreArgs) {
   if (args.clientId) hash.update(args.clientId.trim());
   if (args.accessTokenUrl) hash.update(args.accessTokenUrl.trim().replace(/^https?:\/\//, ""));
   if (args.authorizationUrl) hash.update(args.authorizationUrl.trim().replace(/^https?:\/\//, ""));
+  if (args.username) hash.update(args.username);
   const key = hash.digest("hex");
   return ["token", key].join("::");
 }

--- a/plugins/auth-oauth2/tests/store.test.ts
+++ b/plugins/auth-oauth2/tests/store.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vite-plus/test";
+import type { TokenStoreArgs } from "../src/store";
+import { getToken, storeToken } from "../src/store";
+
+function createMockContext() {
+  const values = new Map<string, unknown>();
+
+  return {
+    store: {
+      async set<T>(key: string, value: T) {
+        values.set(key, value);
+      },
+      async get<T>(key: string) {
+        return values.get(key) as T | undefined;
+      },
+    },
+  } as never;
+}
+
+describe("token store", () => {
+  test("separates password grant tokens when the username changes", async () => {
+    const ctx = createMockContext();
+
+    const aliceArgs: TokenStoreArgs = {
+      contextId: "request-1",
+      clientId: "client-123",
+      accessTokenUrl: "https://auth.example.com/token",
+      authorizationUrl: null,
+      username: "alice@example.com",
+    };
+    const bobArgs: TokenStoreArgs = { ...aliceArgs, username: "bob@example.com" };
+
+    await storeToken(ctx, aliceArgs, { access_token: "alice-token" });
+
+    expect((await getToken(ctx, aliceArgs))?.response.access_token).toBe("alice-token");
+    expect(await getToken(ctx, bobArgs)).toBeUndefined();
+  });
+
+  test("keeps the same key for grants without a username", async () => {
+    const ctx = createMockContext();
+
+    const args: TokenStoreArgs = {
+      contextId: "request-1",
+      clientId: "client-123",
+      accessTokenUrl: "https://auth.example.com/token",
+      authorizationUrl: null,
+    };
+
+    await storeToken(ctx, args, { access_token: "cc-token" });
+
+    expect((await getToken(ctx, { ...args, username: null }))?.response.access_token).toBe(
+      "cc-token",
+    );
+    expect((await getToken(ctx, { ...args, username: "" }))?.response.access_token).toBe("cc-token");
+  });
+});


### PR DESCRIPTION
## Summary

When using environments to switch between users on the same OAuth2 server, the username isn't used when defining the `tokenStoreKey`, so the token of a different user is used after switching the environment that causes the username to change.

Without this fix, I have to use a workaround by modifying the Access Token URL so the `tokenStoreKey` changes. See screenshot below.

<img width="776" height="621" alt="afbeelding" src="https://github.com/user-attachments/assets/3552ccd8-924a-485f-a24a-873294bbabdf" />

## Submission

- [X] This PR is a bug fix or small-scope improvement.
- [ ] If this PR is not a bug fix or small-scope improvement, I linked an approved feedback item below.
- [X] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [ ] I tested this change locally.
- [X] I added or updated tests when reasonable.

Approved feedback item (required if not a bug fix or small-scope improvement):
<!-- https://yaak.app/feedback/... -->

## Related

<!-- Link related issues, discussions, or feedback items. -->
https://yaak.app/feedback/posts/changing-the-environment-doesn-t-invalidate-my-authentication-token