### PR TITLE
feat: support importing multiple files at once

### DIFF
--- a/src-web/components/ImportDataDialog.tsx
+++ b/src-web/components/ImportDataDialog.tsx
@@ -1,16 +1,23 @@
+import { open } from '@tauri-apps/plugin-dialog';
 import { useState } from 'react';
-import { useLocalStorage } from 'react-use';
 import { Button } from './core/Button';
 import { VStack } from './core/Stacks';
-import { SelectFile } from './SelectFile';
 
 interface Props {
-  importData: (filePath: string) => Promise<void>;
+  importData: (filePaths: string[]) => Promise<void>;
 }
 
 export function ImportDataDialog({ importData }: Props) {
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [filePath, setFilePath] = useLocalStorage<string | null>('importFilePath', null);
+  const [filePaths, setFilePaths] = useState<string[]>([]);
+
+  const handleSelectFiles = async () => {
+    const result = await open({ title: 'Select File(s)', multiple: true });
+    if (result == null) return;
+    setFilePaths(Array.isArray(result) ? result : [result]);
+  };
+
+  const fileCount = filePaths.length;
 
   return (
     <VStack space={5} className="pb-4">
@@ -26,20 +33,21 @@ export function ImportDataDialog({ importData }: Props) {
         </ul>
       </VStack>
       <VStack space={2}>
-        <SelectFile
-          filePath={filePath ?? null}
-          onChange={({ filePath }) => setFilePath(filePath)}
-        />
-        {filePath && (
+        <Button color="secondary" size="sm" onClick={handleSelectFiles}>
+          {fileCount > 0
+            ? `${fileCount} file${fileCount !== 1 ? 's' : ''} selected`
+            : 'Select File(s)'}
+        </Button>
+        {fileCount > 0 && (
           <Button
             color="primary"
-            disabled={!filePath || isLoading}
+            disabled={isLoading}
             isLoading={isLoading}
             size="sm"
             onClick={async () => {
               setIsLoading(true);
               try {
-                await importData(filePath);
+                await importData(filePaths);
               } finally {
                 setIsLoading(false);
               }

--- a/src-web/lib/importData.tsx
+++ b/src-web/lib/importData.tsx
@@ -29,9 +29,9 @@ export const importData = createFastMutation({
         title: 'Import Data',
         size: 'sm',
         render: ({ hide }) => {
-          const importAndHide = async (filePath: string) => {
+          const importAndHide = async (filePaths: string[]) => {
             try {
-              const didImport = await performImport(filePath);
+              const didImport = await performImport(filePaths);
               if (!didImport) {
                 return;
               }
@@ -49,14 +49,32 @@ export const importData = createFastMutation({
   },
 });
 
-async function performImport(filePath: string): Promise<boolean> {
+async function performImport(filePaths: string[]): Promise<boolean> {
   const activeWorkspace = jotaiStore.get(activeWorkspaceAtom);
-  const imported = await invokeCmd<BatchUpsertResult>('cmd_import_data', {
-    filePath,
-    workspaceId: activeWorkspace?.id,
-  });
 
-  const importedWorkspace = imported.workspaces[0];
+  const combined: BatchUpsertResult = {
+    workspaces: [],
+    environments: [],
+    folders: [],
+    httpRequests: [],
+    grpcRequests: [],
+    websocketRequests: [],
+  };
+
+  for (const filePath of filePaths) {
+    const imported = await invokeCmd<BatchUpsertResult>('cmd_import_data', {
+      filePath,
+      workspaceId: activeWorkspace?.id,
+    });
+    combined.workspaces.push(...imported.workspaces);
+    combined.environments.push(...imported.environments);
+    combined.folders.push(...imported.folders);
+    combined.httpRequests.push(...imported.httpRequests);
+    combined.grpcRequests.push(...imported.grpcRequests);
+    combined.websocketRequests.push(...imported.websocketRequests);
+  }
+
+  const importedWorkspace = combined.workspaces[0];
 
   showDialog({
     id: 'import-complete',
@@ -67,23 +85,23 @@ async function performImport(filePath: string): Promise<boolean> {
       return (
         <VStack space={3} className="pb-4">
           <ul className="list-disc pl-6">
-            {imported.workspaces.length > 0 && (
-              <li>{pluralizeCount('Workspace', imported.workspaces.length)}</li>
+            {combined.workspaces.length > 0 && (
+              <li>{pluralizeCount('Workspace', combined.workspaces.length)}</li>
             )}
-            {imported.environments.length > 0 && (
-              <li>{pluralizeCount('Environment', imported.environments.length)}</li>
+            {combined.environments.length > 0 && (
+              <li>{pluralizeCount('Environment', combined.environments.length)}</li>
             )}
-            {imported.folders.length > 0 && (
-              <li>{pluralizeCount('Folder', imported.folders.length)}</li>
+            {combined.folders.length > 0 && (
+              <li>{pluralizeCount('Folder', combined.folders.length)}</li>
             )}
-            {imported.httpRequests.length > 0 && (
-              <li>{pluralizeCount('HTTP Request', imported.httpRequests.length)}</li>
+            {combined.httpRequests.length > 0 && (
+              <li>{pluralizeCount('HTTP Request', combined.httpRequests.length)}</li>
             )}
-            {imported.grpcRequests.length > 0 && (
-              <li>{pluralizeCount('GRPC Request', imported.grpcRequests.length)}</li>
+            {combined.grpcRequests.length > 0 && (
+              <li>{pluralizeCount('GRPC Request', combined.grpcRequests.length)}</li>
             )}
-            {imported.websocketRequests.length > 0 && (
-              <li>{pluralizeCount('Websocket Request', imported.websocketRequests.length)}</li>
+            {combined.websocketRequests.length > 0 && (
+              <li>{pluralizeCount('Websocket Request', combined.websocketRequests.length)}</li>
             )}
           </ul>
           <div>
@@ -97,7 +115,7 @@ async function performImport(filePath: string): Promise<boolean> {
   });
 
   if (importedWorkspace != null) {
-    const environmentId = imported.environments[0]?.id ?? null;
+    const environmentId = combined.environments[0]?.id ?? null;
     await router.navigate({
       to: '/workspaces/$workspaceId',
       params: { workspaceId: importedWorkspace.id },


### PR DESCRIPTION
## Summary

- Replaces the single-file picker in the import dialog with a multi-file picker (`multiple: true`)
- Files are imported sequentially to avoid database conflicts
- All results are aggregated into a single combined summary dialog
- Removes the `useLocalStorage` dependency for the file path (no longer needed)

## Motivation

When importing a Postman data export (which produces a folder of individual collection JSON files), users had to go through the import dialog once per file. This change allows selecting all files at once.

## Test plan

- [ ] Open Import dialog — button should read "Select File(s)"
- [ ] Select a single file — imports and shows summary as before
- [ ] Select multiple files — all are imported, summary shows combined totals (e.g. "3 Workspaces, 45 HTTP Requests")
- [ ] Cancel file picker — nothing happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)