### PR TITLE
Fix duplicate request snapshotting URL as name

### DIFF
--- a/crates/yaak-models/guest-js/store.ts
+++ b/crates/yaak-models/guest-js/store.ts
@@ -146,7 +146,10 @@ export function duplicateModel<M extends AnyModel["model"], T extends ExtractMod
 
   // If the model has an explicit (non-empty) name, try to duplicate it with a name that doesn't conflict.
   // When the name is empty, keep it empty so the display falls back to the URL.
-  let name: string | undefined = "name" in model ? (model as { name: string }).name : undefined;
+  let name: string | undefined;
+  if ("name" in model) {
+    name = (model as { name: string }).name;
+  }
   if (name) {
     const existingModels = listModels(model.model);
     for (let i = 0; i < 100; i++) {

--- a/crates/yaak-models/guest-js/store.ts
+++ b/crates/yaak-models/guest-js/store.ts
@@ -151,6 +151,7 @@ export function duplicateModel<M extends AnyModel["model"], T extends ExtractMod
     name = (model as { name: string }).name;
   }
   if (name) {
+    name = resolvedModelName(model);
     const existingModels = listModels(model.model);
     for (let i = 0; i < 100; i++) {
       const hasConflict = existingModels.some((m) => {

--- a/crates/yaak-models/guest-js/store.ts
+++ b/crates/yaak-models/guest-js/store.ts
@@ -148,7 +148,7 @@ export function duplicateModel<M extends AnyModel["model"], T extends ExtractMod
   // When the name is empty, keep it empty so the display falls back to the URL.
   let name: string | undefined;
   if ("name" in model) {
-    name = (model as { name: string }).name;
+    name = model.name;
   }
   if (name) {
     const existingModels = listModels(model.model);

--- a/crates/yaak-models/guest-js/store.ts
+++ b/crates/yaak-models/guest-js/store.ts
@@ -144,9 +144,10 @@ export function duplicateModel<M extends AnyModel["model"], T extends ExtractMod
     throw new Error("Failed to duplicate null model");
   }
 
-  // If the model has a name, try to duplicate it with a name that doesn't conflict
-  let name = "name" in model ? resolvedModelName(model) : undefined;
-  if (name != null) {
+  // If the model has an explicit (non-empty) name, try to duplicate it with a name that doesn't conflict.
+  // When the name is empty, keep it empty so the display falls back to the URL.
+  let name: string | undefined = "name" in model ? (model as { name: string }).name : undefined;
+  if (name) {
     const existingModels = listModels(model.model);
     for (let i = 0; i < 100; i++) {
       const hasConflict = existingModels.some((m) => {

--- a/crates/yaak-models/guest-js/store.ts
+++ b/crates/yaak-models/guest-js/store.ts
@@ -151,7 +151,6 @@ export function duplicateModel<M extends AnyModel["model"], T extends ExtractMod
     name = (model as { name: string }).name;
   }
   if (name) {
-    name = resolvedModelName(model);
     const existingModels = listModels(model.model);
     for (let i = 0; i < 100; i++) {
       const hasConflict = existingModels.some((m) => {

--- a/crates/yaak-models/guest-js/store.ts
+++ b/crates/yaak-models/guest-js/store.ts
@@ -146,10 +146,7 @@ export function duplicateModel<M extends AnyModel["model"], T extends ExtractMod
 
   // If the model has an explicit (non-empty) name, try to duplicate it with a name that doesn't conflict.
   // When the name is empty, keep it empty so the display falls back to the URL.
-  let name: string | undefined;
-  if ("name" in model) {
-    name = model.name;
-  }
+  let name = "name" in model ? model.name : undefined;
   if (name) {
     const existingModels = listModels(model.model);
     for (let i = 0; i < 100; i++) {


### PR DESCRIPTION
## Summary
- When duplicating an unnamed request (where the sidebar shows the URL as fallback), the URL was being "snapshotted" as the duplicate's explicit name
- Now the raw `name` field is preserved — empty names stay empty, so duplicates continue to dynamically display the URL
- Requests with explicit names still get the "Copy" suffix conflict resolution as before