### PR TITLE
fix: AWS4 authentication method didn't sign request body

### DIFF
--- a/apps/yaak-client/routeTree.gen.ts
+++ b/apps/yaak-client/routeTree.gen.ts
@@ -8,131 +8,133 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as IndexRouteImport } from "./routes/index";
-import { Route as WorkspacesIndexRouteImport } from "./routes/workspaces/index";
-import { Route as WorkspacesWorkspaceIdIndexRouteImport } from "./routes/workspaces/$workspaceId/index";
-import { Route as WorkspacesWorkspaceIdSettingsRouteImport } from "./routes/workspaces/$workspaceId/settings";
-import { Route as WorkspacesWorkspaceIdRequestsRequestIdRouteImport } from "./routes/workspaces/$workspaceId/requests/$requestId";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as WorkspacesIndexRouteImport } from './routes/workspaces/index'
+import { Route as WorkspacesWorkspaceIdIndexRouteImport } from './routes/workspaces/$workspaceId/index'
+import { Route as WorkspacesWorkspaceIdSettingsRouteImport } from './routes/workspaces/$workspaceId/settings'
+import { Route as WorkspacesWorkspaceIdRequestsRequestIdRouteImport } from './routes/workspaces/$workspaceId/requests/$requestId'
 
 const IndexRoute = IndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const WorkspacesIndexRoute = WorkspacesIndexRouteImport.update({
-  id: "/workspaces/",
-  path: "/workspaces/",
+  id: '/workspaces/',
+  path: '/workspaces/',
   getParentRoute: () => rootRouteImport,
-} as any);
-const WorkspacesWorkspaceIdIndexRoute = WorkspacesWorkspaceIdIndexRouteImport.update({
-  id: "/workspaces/$workspaceId/",
-  path: "/workspaces/$workspaceId/",
-  getParentRoute: () => rootRouteImport,
-} as any);
-const WorkspacesWorkspaceIdSettingsRoute = WorkspacesWorkspaceIdSettingsRouteImport.update({
-  id: "/workspaces/$workspaceId/settings",
-  path: "/workspaces/$workspaceId/settings",
-  getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
+const WorkspacesWorkspaceIdIndexRoute =
+  WorkspacesWorkspaceIdIndexRouteImport.update({
+    id: '/workspaces/$workspaceId/',
+    path: '/workspaces/$workspaceId/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const WorkspacesWorkspaceIdSettingsRoute =
+  WorkspacesWorkspaceIdSettingsRouteImport.update({
+    id: '/workspaces/$workspaceId/settings',
+    path: '/workspaces/$workspaceId/settings',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const WorkspacesWorkspaceIdRequestsRequestIdRoute =
   WorkspacesWorkspaceIdRequestsRequestIdRouteImport.update({
-    id: "/workspaces/$workspaceId/requests/$requestId",
-    path: "/workspaces/$workspaceId/requests/$requestId",
+    id: '/workspaces/$workspaceId/requests/$requestId',
+    path: '/workspaces/$workspaceId/requests/$requestId',
     getParentRoute: () => rootRouteImport,
-  } as any);
+  } as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute;
-  "/workspaces": typeof WorkspacesIndexRoute;
-  "/workspaces/$workspaceId/settings": typeof WorkspacesWorkspaceIdSettingsRoute;
-  "/workspaces/$workspaceId": typeof WorkspacesWorkspaceIdIndexRoute;
-  "/workspaces/$workspaceId/requests/$requestId": typeof WorkspacesWorkspaceIdRequestsRequestIdRoute;
+  '/': typeof IndexRoute
+  '/workspaces': typeof WorkspacesIndexRoute
+  '/workspaces/$workspaceId/settings': typeof WorkspacesWorkspaceIdSettingsRoute
+  '/workspaces/$workspaceId': typeof WorkspacesWorkspaceIdIndexRoute
+  '/workspaces/$workspaceId/requests/$requestId': typeof WorkspacesWorkspaceIdRequestsRequestIdRoute
 }
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute;
-  "/workspaces": typeof WorkspacesIndexRoute;
-  "/workspaces/$workspaceId/settings": typeof WorkspacesWorkspaceIdSettingsRoute;
-  "/workspaces/$workspaceId": typeof WorkspacesWorkspaceIdIndexRoute;
-  "/workspaces/$workspaceId/requests/$requestId": typeof WorkspacesWorkspaceIdRequestsRequestIdRoute;
+  '/': typeof IndexRoute
+  '/workspaces': typeof WorkspacesIndexRoute
+  '/workspaces/$workspaceId/settings': typeof WorkspacesWorkspaceIdSettingsRoute
+  '/workspaces/$workspaceId': typeof WorkspacesWorkspaceIdIndexRoute
+  '/workspaces/$workspaceId/requests/$requestId': typeof WorkspacesWorkspaceIdRequestsRequestIdRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/": typeof IndexRoute;
-  "/workspaces/": typeof WorkspacesIndexRoute;
-  "/workspaces/$workspaceId/settings": typeof WorkspacesWorkspaceIdSettingsRoute;
-  "/workspaces/$workspaceId/": typeof WorkspacesWorkspaceIdIndexRoute;
-  "/workspaces/$workspaceId/requests/$requestId": typeof WorkspacesWorkspaceIdRequestsRequestIdRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/workspaces/': typeof WorkspacesIndexRoute
+  '/workspaces/$workspaceId/settings': typeof WorkspacesWorkspaceIdSettingsRoute
+  '/workspaces/$workspaceId/': typeof WorkspacesWorkspaceIdIndexRoute
+  '/workspaces/$workspaceId/requests/$requestId': typeof WorkspacesWorkspaceIdRequestsRequestIdRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | "/"
-    | "/workspaces"
-    | "/workspaces/$workspaceId/settings"
-    | "/workspaces/$workspaceId"
-    | "/workspaces/$workspaceId/requests/$requestId";
-  fileRoutesByTo: FileRoutesByTo;
+    | '/'
+    | '/workspaces'
+    | '/workspaces/$workspaceId/settings'
+    | '/workspaces/$workspaceId'
+    | '/workspaces/$workspaceId/requests/$requestId'
+  fileRoutesByTo: FileRoutesByTo
   to:
-    | "/"
-    | "/workspaces"
-    | "/workspaces/$workspaceId/settings"
-    | "/workspaces/$workspaceId"
-    | "/workspaces/$workspaceId/requests/$requestId";
+    | '/'
+    | '/workspaces'
+    | '/workspaces/$workspaceId/settings'
+    | '/workspaces/$workspaceId'
+    | '/workspaces/$workspaceId/requests/$requestId'
   id:
-    | "__root__"
-    | "/"
-    | "/workspaces/"
-    | "/workspaces/$workspaceId/settings"
-    | "/workspaces/$workspaceId/"
-    | "/workspaces/$workspaceId/requests/$requestId";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/'
+    | '/workspaces/'
+    | '/workspaces/$workspaceId/settings'
+    | '/workspaces/$workspaceId/'
+    | '/workspaces/$workspaceId/requests/$requestId'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  WorkspacesIndexRoute: typeof WorkspacesIndexRoute;
-  WorkspacesWorkspaceIdSettingsRoute: typeof WorkspacesWorkspaceIdSettingsRoute;
-  WorkspacesWorkspaceIdIndexRoute: typeof WorkspacesWorkspaceIdIndexRoute;
-  WorkspacesWorkspaceIdRequestsRequestIdRoute: typeof WorkspacesWorkspaceIdRequestsRequestIdRoute;
+  IndexRoute: typeof IndexRoute
+  WorkspacesIndexRoute: typeof WorkspacesIndexRoute
+  WorkspacesWorkspaceIdSettingsRoute: typeof WorkspacesWorkspaceIdSettingsRoute
+  WorkspacesWorkspaceIdIndexRoute: typeof WorkspacesWorkspaceIdIndexRoute
+  WorkspacesWorkspaceIdRequestsRequestIdRoute: typeof WorkspacesWorkspaceIdRequestsRequestIdRoute
 }
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/workspaces/": {
-      id: "/workspaces/";
-      path: "/workspaces";
-      fullPath: "/workspaces";
-      preLoaderRoute: typeof WorkspacesIndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/workspaces/$workspaceId/": {
-      id: "/workspaces/$workspaceId/";
-      path: "/workspaces/$workspaceId";
-      fullPath: "/workspaces/$workspaceId";
-      preLoaderRoute: typeof WorkspacesWorkspaceIdIndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/workspaces/$workspaceId/settings": {
-      id: "/workspaces/$workspaceId/settings";
-      path: "/workspaces/$workspaceId/settings";
-      fullPath: "/workspaces/$workspaceId/settings";
-      preLoaderRoute: typeof WorkspacesWorkspaceIdSettingsRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/workspaces/$workspaceId/requests/$requestId": {
-      id: "/workspaces/$workspaceId/requests/$requestId";
-      path: "/workspaces/$workspaceId/requests/$requestId";
-      fullPath: "/workspaces/$workspaceId/requests/$requestId";
-      preLoaderRoute: typeof WorkspacesWorkspaceIdRequestsRequestIdRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/workspaces/': {
+      id: '/workspaces/'
+      path: '/workspaces'
+      fullPath: '/workspaces'
+      preLoaderRoute: typeof WorkspacesIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/workspaces/$workspaceId/': {
+      id: '/workspaces/$workspaceId/'
+      path: '/workspaces/$workspaceId'
+      fullPath: '/workspaces/$workspaceId'
+      preLoaderRoute: typeof WorkspacesWorkspaceIdIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/workspaces/$workspaceId/settings': {
+      id: '/workspaces/$workspaceId/settings'
+      path: '/workspaces/$workspaceId/settings'
+      fullPath: '/workspaces/$workspaceId/settings'
+      preLoaderRoute: typeof WorkspacesWorkspaceIdSettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/workspaces/$workspaceId/requests/$requestId': {
+      id: '/workspaces/$workspaceId/requests/$requestId'
+      path: '/workspaces/$workspaceId/requests/$requestId'
+      fullPath: '/workspaces/$workspaceId/requests/$requestId'
+      preLoaderRoute: typeof WorkspacesWorkspaceIdRequestsRequestIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -141,8 +143,9 @@ const rootRouteChildren: RootRouteChildren = {
   WorkspacesIndexRoute: WorkspacesIndexRoute,
   WorkspacesWorkspaceIdSettingsRoute: WorkspacesWorkspaceIdSettingsRoute,
   WorkspacesWorkspaceIdIndexRoute: WorkspacesWorkspaceIdIndexRoute,
-  WorkspacesWorkspaceIdRequestsRequestIdRoute: WorkspacesWorkspaceIdRequestsRequestIdRoute,
-};
+  WorkspacesWorkspaceIdRequestsRequestIdRoute:
+    WorkspacesWorkspaceIdRequestsRequestIdRoute,
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()

--- a/apps/yaak-client/routeTree.gen.ts
+++ b/apps/yaak-client/routeTree.gen.ts
@@ -8,133 +8,131 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as WorkspacesIndexRouteImport } from './routes/workspaces/index'
-import { Route as WorkspacesWorkspaceIdIndexRouteImport } from './routes/workspaces/$workspaceId/index'
-import { Route as WorkspacesWorkspaceIdSettingsRouteImport } from './routes/workspaces/$workspaceId/settings'
-import { Route as WorkspacesWorkspaceIdRequestsRequestIdRouteImport } from './routes/workspaces/$workspaceId/requests/$requestId'
+import { Route as rootRouteImport } from "./routes/__root";
+import { Route as IndexRouteImport } from "./routes/index";
+import { Route as WorkspacesIndexRouteImport } from "./routes/workspaces/index";
+import { Route as WorkspacesWorkspaceIdIndexRouteImport } from "./routes/workspaces/$workspaceId/index";
+import { Route as WorkspacesWorkspaceIdSettingsRouteImport } from "./routes/workspaces/$workspaceId/settings";
+import { Route as WorkspacesWorkspaceIdRequestsRequestIdRouteImport } from "./routes/workspaces/$workspaceId/requests/$requestId";
 
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+  id: "/",
+  path: "/",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const WorkspacesIndexRoute = WorkspacesIndexRouteImport.update({
-  id: '/workspaces/',
-  path: '/workspaces/',
+  id: "/workspaces/",
+  path: "/workspaces/",
   getParentRoute: () => rootRouteImport,
-} as any)
-const WorkspacesWorkspaceIdIndexRoute =
-  WorkspacesWorkspaceIdIndexRouteImport.update({
-    id: '/workspaces/$workspaceId/',
-    path: '/workspaces/$workspaceId/',
-    getParentRoute: () => rootRouteImport,
-  } as any)
-const WorkspacesWorkspaceIdSettingsRoute =
-  WorkspacesWorkspaceIdSettingsRouteImport.update({
-    id: '/workspaces/$workspaceId/settings',
-    path: '/workspaces/$workspaceId/settings',
-    getParentRoute: () => rootRouteImport,
-  } as any)
+} as any);
+const WorkspacesWorkspaceIdIndexRoute = WorkspacesWorkspaceIdIndexRouteImport.update({
+  id: "/workspaces/$workspaceId/",
+  path: "/workspaces/$workspaceId/",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const WorkspacesWorkspaceIdSettingsRoute = WorkspacesWorkspaceIdSettingsRouteImport.update({
+  id: "/workspaces/$workspaceId/settings",
+  path: "/workspaces/$workspaceId/settings",
+  getParentRoute: () => rootRouteImport,
+} as any);
 const WorkspacesWorkspaceIdRequestsRequestIdRoute =
   WorkspacesWorkspaceIdRequestsRequestIdRouteImport.update({
-    id: '/workspaces/$workspaceId/requests/$requestId',
-    path: '/workspaces/$workspaceId/requests/$requestId',
+    id: "/workspaces/$workspaceId/requests/$requestId",
+    path: "/workspaces/$workspaceId/requests/$requestId",
     getParentRoute: () => rootRouteImport,
-  } as any)
+  } as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/workspaces': typeof WorkspacesIndexRoute
-  '/workspaces/$workspaceId/settings': typeof WorkspacesWorkspaceIdSettingsRoute
-  '/workspaces/$workspaceId': typeof WorkspacesWorkspaceIdIndexRoute
-  '/workspaces/$workspaceId/requests/$requestId': typeof WorkspacesWorkspaceIdRequestsRequestIdRoute
+  "/": typeof IndexRoute;
+  "/workspaces": typeof WorkspacesIndexRoute;
+  "/workspaces/$workspaceId/settings": typeof WorkspacesWorkspaceIdSettingsRoute;
+  "/workspaces/$workspaceId": typeof WorkspacesWorkspaceIdIndexRoute;
+  "/workspaces/$workspaceId/requests/$requestId": typeof WorkspacesWorkspaceIdRequestsRequestIdRoute;
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/workspaces': typeof WorkspacesIndexRoute
-  '/workspaces/$workspaceId/settings': typeof WorkspacesWorkspaceIdSettingsRoute
-  '/workspaces/$workspaceId': typeof WorkspacesWorkspaceIdIndexRoute
-  '/workspaces/$workspaceId/requests/$requestId': typeof WorkspacesWorkspaceIdRequestsRequestIdRoute
+  "/": typeof IndexRoute;
+  "/workspaces": typeof WorkspacesIndexRoute;
+  "/workspaces/$workspaceId/settings": typeof WorkspacesWorkspaceIdSettingsRoute;
+  "/workspaces/$workspaceId": typeof WorkspacesWorkspaceIdIndexRoute;
+  "/workspaces/$workspaceId/requests/$requestId": typeof WorkspacesWorkspaceIdRequestsRequestIdRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/workspaces/': typeof WorkspacesIndexRoute
-  '/workspaces/$workspaceId/settings': typeof WorkspacesWorkspaceIdSettingsRoute
-  '/workspaces/$workspaceId/': typeof WorkspacesWorkspaceIdIndexRoute
-  '/workspaces/$workspaceId/requests/$requestId': typeof WorkspacesWorkspaceIdRequestsRequestIdRoute
+  __root__: typeof rootRouteImport;
+  "/": typeof IndexRoute;
+  "/workspaces/": typeof WorkspacesIndexRoute;
+  "/workspaces/$workspaceId/settings": typeof WorkspacesWorkspaceIdSettingsRoute;
+  "/workspaces/$workspaceId/": typeof WorkspacesWorkspaceIdIndexRoute;
+  "/workspaces/$workspaceId/requests/$requestId": typeof WorkspacesWorkspaceIdRequestsRequestIdRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
+  fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
-    | '/'
-    | '/workspaces'
-    | '/workspaces/$workspaceId/settings'
-    | '/workspaces/$workspaceId'
-    | '/workspaces/$workspaceId/requests/$requestId'
-  fileRoutesByTo: FileRoutesByTo
+    | "/"
+    | "/workspaces"
+    | "/workspaces/$workspaceId/settings"
+    | "/workspaces/$workspaceId"
+    | "/workspaces/$workspaceId/requests/$requestId";
+  fileRoutesByTo: FileRoutesByTo;
   to:
-    | '/'
-    | '/workspaces'
-    | '/workspaces/$workspaceId/settings'
-    | '/workspaces/$workspaceId'
-    | '/workspaces/$workspaceId/requests/$requestId'
+    | "/"
+    | "/workspaces"
+    | "/workspaces/$workspaceId/settings"
+    | "/workspaces/$workspaceId"
+    | "/workspaces/$workspaceId/requests/$requestId";
   id:
-    | '__root__'
-    | '/'
-    | '/workspaces/'
-    | '/workspaces/$workspaceId/settings'
-    | '/workspaces/$workspaceId/'
-    | '/workspaces/$workspaceId/requests/$requestId'
-  fileRoutesById: FileRoutesById
+    | "__root__"
+    | "/"
+    | "/workspaces/"
+    | "/workspaces/$workspaceId/settings"
+    | "/workspaces/$workspaceId/"
+    | "/workspaces/$workspaceId/requests/$requestId";
+  fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  WorkspacesIndexRoute: typeof WorkspacesIndexRoute
-  WorkspacesWorkspaceIdSettingsRoute: typeof WorkspacesWorkspaceIdSettingsRoute
-  WorkspacesWorkspaceIdIndexRoute: typeof WorkspacesWorkspaceIdIndexRoute
-  WorkspacesWorkspaceIdRequestsRequestIdRoute: typeof WorkspacesWorkspaceIdRequestsRequestIdRoute
+  IndexRoute: typeof IndexRoute;
+  WorkspacesIndexRoute: typeof WorkspacesIndexRoute;
+  WorkspacesWorkspaceIdSettingsRoute: typeof WorkspacesWorkspaceIdSettingsRoute;
+  WorkspacesWorkspaceIdIndexRoute: typeof WorkspacesWorkspaceIdIndexRoute;
+  WorkspacesWorkspaceIdRequestsRequestIdRoute: typeof WorkspacesWorkspaceIdRequestsRequestIdRoute;
 }
 
-declare module '@tanstack/react-router' {
+declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/workspaces/': {
-      id: '/workspaces/'
-      path: '/workspaces'
-      fullPath: '/workspaces'
-      preLoaderRoute: typeof WorkspacesIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/workspaces/$workspaceId/': {
-      id: '/workspaces/$workspaceId/'
-      path: '/workspaces/$workspaceId'
-      fullPath: '/workspaces/$workspaceId'
-      preLoaderRoute: typeof WorkspacesWorkspaceIdIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/workspaces/$workspaceId/settings': {
-      id: '/workspaces/$workspaceId/settings'
-      path: '/workspaces/$workspaceId/settings'
-      fullPath: '/workspaces/$workspaceId/settings'
-      preLoaderRoute: typeof WorkspacesWorkspaceIdSettingsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/workspaces/$workspaceId/requests/$requestId': {
-      id: '/workspaces/$workspaceId/requests/$requestId'
-      path: '/workspaces/$workspaceId/requests/$requestId'
-      fullPath: '/workspaces/$workspaceId/requests/$requestId'
-      preLoaderRoute: typeof WorkspacesWorkspaceIdRequestsRequestIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+    "/": {
+      id: "/";
+      path: "/";
+      fullPath: "/";
+      preLoaderRoute: typeof IndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/workspaces/": {
+      id: "/workspaces/";
+      path: "/workspaces";
+      fullPath: "/workspaces";
+      preLoaderRoute: typeof WorkspacesIndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/workspaces/$workspaceId/": {
+      id: "/workspaces/$workspaceId/";
+      path: "/workspaces/$workspaceId";
+      fullPath: "/workspaces/$workspaceId";
+      preLoaderRoute: typeof WorkspacesWorkspaceIdIndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/workspaces/$workspaceId/settings": {
+      id: "/workspaces/$workspaceId/settings";
+      path: "/workspaces/$workspaceId/settings";
+      fullPath: "/workspaces/$workspaceId/settings";
+      preLoaderRoute: typeof WorkspacesWorkspaceIdSettingsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/workspaces/$workspaceId/requests/$requestId": {
+      id: "/workspaces/$workspaceId/requests/$requestId";
+      path: "/workspaces/$workspaceId/requests/$requestId";
+      fullPath: "/workspaces/$workspaceId/requests/$requestId";
+      preLoaderRoute: typeof WorkspacesWorkspaceIdRequestsRequestIdRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
   }
 }
 
@@ -143,9 +141,8 @@ const rootRouteChildren: RootRouteChildren = {
   WorkspacesIndexRoute: WorkspacesIndexRoute,
   WorkspacesWorkspaceIdSettingsRoute: WorkspacesWorkspaceIdSettingsRoute,
   WorkspacesWorkspaceIdIndexRoute: WorkspacesWorkspaceIdIndexRoute,
-  WorkspacesWorkspaceIdRequestsRequestIdRoute:
-    WorkspacesWorkspaceIdRequestsRequestIdRoute,
-}
+  WorkspacesWorkspaceIdRequestsRequestIdRoute: WorkspacesWorkspaceIdRequestsRequestIdRoute,
+};
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();

--- a/crates-tauri/yaak-app-client/src/grpc.rs
+++ b/crates-tauri/yaak-app-client/src/grpc.rs
@@ -80,6 +80,7 @@ pub(crate) async fn build_metadata<R: Runtime>(
                         value: value.to_string(),
                     })
                     .collect(),
+                body: None,
             };
             let plugin_result = plugin_manager
                 .call_http_authentication(

--- a/crates-tauri/yaak-app-client/src/ws_ext.rs
+++ b/crates-tauri/yaak-app-client/src/ws_ext.rs
@@ -251,6 +251,7 @@ pub async fn cmd_ws_connect<R: Runtime>(
                     .into_iter()
                     .map(|h| HttpHeader { name: h.name, value: h.value })
                     .collect(),
+                body: None,
             };
             let plugin_result = plugin_manager
                 .call_http_authentication(

--- a/crates/yaak-plugins/bindings/gen_events.ts
+++ b/crates/yaak-plugins/bindings/gen_events.ts
@@ -16,7 +16,7 @@ export type CallHttpAuthenticationActionArgs = { contextId: string, values: { [k
 
 export type CallHttpAuthenticationActionRequest = { index: number, pluginRefId: string, args: CallHttpAuthenticationActionArgs, };
 
-export type CallHttpAuthenticationRequest = { contextId: string, values: { [key in string]?: JsonPrimitive }, method: string, url: string, headers: Array<HttpHeader>, };
+export type CallHttpAuthenticationRequest = { contextId: string, values: { [key in string]?: JsonPrimitive }, method: string, url: string, headers: Array<HttpHeader>, body: string | null, };
 
 export type CallHttpAuthenticationResponse = { 
 /**

--- a/crates/yaak-plugins/src/events.rs
+++ b/crates/yaak-plugins/src/events.rs
@@ -746,6 +746,7 @@ pub struct CallHttpAuthenticationRequest {
     pub method: String,
     pub url: String,
     pub headers: Vec<HttpHeader>,
+    pub body: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, TS)]

--- a/crates/yaak/src/send.rs
+++ b/crates/yaak/src/send.rs
@@ -41,6 +41,7 @@ use yaak_tls::find_client_certificate;
 const HTTP_EVENT_CHANNEL_CAPACITY: usize = 100;
 const REQUEST_BODY_CHUNK_SIZE: usize = 1024 * 1024;
 const RESPONSE_PROGRESS_UPDATE_INTERVAL_MS: u128 = 100;
+const MAX_AUTH_BODY_BYTES: usize = 10 * 1024 * 1024;
 
 #[derive(Debug, Error)]
 pub enum SendHttpRequestError {
@@ -1087,7 +1088,12 @@ pub async fn apply_plugin_authentication(
                     })
                     .collect(),
                 body: match &sendable_request.body {
-                    Some(SendableBody::Bytes(bytes)) => {
+                    // Bodies above the cap are not passed to auth plugins. Copying
+                    // them across the plugin IPC is too expensive, and payloads that
+                    // large are usually uploads that signing schemes treat as
+                    // unsigned anyway. Streamed bodies (files, multipart) are never
+                    // passed for the same reason.
+                    Some(SendableBody::Bytes(bytes)) if bytes.len() <= MAX_AUTH_BODY_BYTES => {
                         String::from_utf8(bytes.to_vec()).ok()
                     }
                     _ => None,

--- a/crates/yaak/src/send.rs
+++ b/crates/yaak/src/send.rs
@@ -1086,6 +1086,12 @@ pub async fn apply_plugin_authentication(
                         value: value.to_string(),
                     })
                     .collect(),
+                body: match &sendable_request.body {
+                    Some(SendableBody::Bytes(bytes)) => {
+                        String::from_utf8(bytes.to_vec()).ok()
+                    }
+                    _ => None,
+                },
             };
             let plugin_result = plugin_manager
                 .call_http_authentication(plugin_context, authentication_type, req)

--- a/packages/plugin-runtime-types/src/bindings/gen_events.ts
+++ b/packages/plugin-runtime-types/src/bindings/gen_events.ts
@@ -16,7 +16,7 @@ export type CallHttpAuthenticationActionArgs = { contextId: string, values: { [k
 
 export type CallHttpAuthenticationActionRequest = { index: number, pluginRefId: string, args: CallHttpAuthenticationActionArgs, };
 
-export type CallHttpAuthenticationRequest = { contextId: string, values: { [key in string]?: JsonPrimitive }, method: string, url: string, headers: Array<HttpHeader>, };
+export type CallHttpAuthenticationRequest = { contextId: string, values: { [key in string]?: JsonPrimitive }, method: string, url: string, headers: Array<HttpHeader>, body: string | null, };
 
 export type CallHttpAuthenticationResponse = { 
 /**

--- a/plugins/auth-aws/src/index.ts
+++ b/plugins/auth-aws/src/index.ts
@@ -65,6 +65,7 @@ export const plugin: PluginDefinition = {
           service: String(values.service || "sts"),
           region: values.region ? String(values.region) : undefined,
           headers,
+          body: args.body ?? undefined,
           doNotEncodePath: true,
         },
         {


### PR DESCRIPTION
## Summary

When using the AWS4 method for authentication, it never added the body to the signature. This meant that only `GET` requests worked, or when not passing a body entirely.

When using a `POST` with a body, the generated `x-amz-security-token` header being passed didn't match what was actually being sent, and results in a 403 response.

The fix is to include the body in the signature generation.

## Submission

- [x] This PR is a bug fix or small-scope improvement.
- [ ] If this PR is not a bug fix or small-scope improvement, I linked an approved feedback item below.
- [x] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [x] I tested this change locally.
- [ ] I added or updated tests when reasonable.

There doesn't seem to be any tests setup within the `auth-aws` package. Happy to add them, although don't know if that would be considered outside the scope of what a "bugfix" would be.

## Related
Before:
![before](https://github.com/user-attachments/assets/69abbf40-a02b-4468-99fe-e1a6e0a93d59)

After:
![after](https://github.com/user-attachments/assets/4fb9224d-e0c2-4b5a-b4da-70dace6f5b1a)

