### PR TITLE
fix: bug where selection layer leaves a ghost residual line below wrapped lines after deselecting

### DIFF
--- a/src-web/components/core/Editor/Editor.css
+++ b/src-web/components/core/Editor/Editor.css
@@ -67,6 +67,13 @@
       @apply bg-selection !important;
     }
 
+    /* Fix WebKit/WKWebView rendering bug where selection layer leaves a ghost
+       residual line below wrapped lines after deselecting (CodeMirror issue #1600, #1627).
+       The layer div must be hidden when empty to force a repaint. */
+    .cm-selectionLayer:empty {
+      display: none;
+    }
+
     /* Style gutters */
 
     .cm-gutters {


### PR DESCRIPTION
## Summary

Fix a visual glitch in the JSON body editor where a ghost/residual line appears below wrapped lines after double-clicking to select and then deselecting. This is a known WebKit rendering bug (CodeMirror issues [#1600](https://github.com/codemirror/dev/issues/1600), [#1627](https://github.com/codemirror/dev/issues/1627)) where the selection layer div doesn't repaint after its children are removed. The fix adds a CSS rule to hide the empty selection layer, forcing WebKit to clear the ghost.

#### Environment
- Mac Mini M4
- MacOS Sequoia 15.6

## Submission

- [X] This PR is a bug fix or small-scope improvement.
- [ ] If this PR is not a bug fix or small-scope improvement, I linked an approved feedback item below.
- [X] I have read and followed [CONTRIBUTING.md](CONTRIBUTING.md).
- [X] I tested this change locally.
- [ ] I added or updated tests when reasonable.

## Related

Before:

https://github.com/user-attachments/assets/f3cbfb32-26e9-4ef0-a1fc-4f12a33d87c2

After: 

https://github.com/user-attachments/assets/5eb57d8e-b901-4385-9e26-95a152e65174

CodeMirror issues:
- CodeMirror issue [#1600 - Selection Background Stuck on iOS](https://github.com/codemirror/dev/issues/1600)
- CodeMirror issue [#1627 - Selection glitch in Safari 26](https://github.com/codemirror/dev/issues/1627)