### PR TITLE
fix: align HTTP method tags to the left

### DIFF
--- a/src-web/components/core/HttpMethodTag.tsx
+++ b/src-web/components/core/HttpMethodTag.tsx
@@ -57,7 +57,7 @@ export function HttpMethodTagRaw({
   let label = method.toUpperCase();
   if (short) {
     label = methodNames[method.toLowerCase()] ?? method.slice(0, 4);
-    label = label.padStart(4, " ");
+    label = label.padEnd(4, " ");
   }
 
   const m = method.toUpperCase();


### PR DESCRIPTION
## Summary

HTTP method tags in the left sidebar are `left-aligned` on the webpage screenshot but `right-aligned` in the app. This PR fixes the alignment by replacing `padStart` with `padEnd` in `HttpMethodTag.tsx` file.


## Submission

- [x] This PR is a bug fix or small-scope improvement.
- [ ] If this PR is not a bug fix or small-scope improvement, I linked an approved feedback item below.
- [x] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [x] I tested this change locally.
- [ ] I added or updated tests when reasonable.


## Screenshots

### Before:
<img width="1100" height="397" alt="Before" src="https://github.com/user-attachments/assets/dd24fb0b-a648-46ec-b899-c3176896e8a7" />


### After fix:
<img width="1098" height="389" alt="Fix" src="https://github.com/user-attachments/assets/b0bd5e94-67bd-4b18-8969-10ace63b86ee" />

