### PR TITLE
Fix: long model names overflowing in delete dialog

### DIFF
--- a/apps/yaak-client/lib/deleteModelWithConfirm.tsx
+++ b/apps/yaak-client/lib/deleteModelWithConfirm.tsx
@@ -35,10 +35,15 @@ export async function deleteModelWithConfirm(
           <>
             the following?
             <Prose className="mt-2">
-              <ul>
+              <ul className="space-y-1">
                 {models.map((m) => (
                   <li key={m.id}>
-                    <InlineCode>{resolvedModelName(m)}</InlineCode>
+                    <InlineCode
+                      className="inline-block truncate align-bottom max-w-full"
+                      title={resolvedModelName(m)}
+                    >
+                      {resolvedModelName(m)}
+                    </InlineCode>
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
Long model names would overflow When deleting more than 1 and less than 10 models.
Opted for truncate to keep the list functionally similar to how it was
intended.
