### PR TITLE
fix(linux): disable WebKit DMA-BUF renderer to prevent Wayland crash

### DIFF
--- a/crates-tauri/yaak-app-client/src/main.rs
+++ b/crates-tauri/yaak-app-client/src/main.rs
@@ -1,5 +1,12 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Prevents a Wayland protocol error (71) in WebKit2GTK's DMA-BUF renderer on some compositors.
+    #[cfg(target_os = "linux")]
+    if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+        // SAFETY: called before any threads are spawned.
+        unsafe { std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1") };
+    }
+
     tauri_app_client_lib::run();
 }

--- a/crates-tauri/yaak-app-client/src/main.rs
+++ b/crates-tauri/yaak-app-client/src/main.rs
@@ -1,11 +1,16 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    // Prevents a Wayland protocol error (71) in WebKit2GTK's DMA-BUF renderer on some compositors.
+    // On Nvidia + Wayland, WebKit2GTK's DMA-BUF renderer triggers a protocol error (71) due to
+    // an explicit sync bug (https://bugs.webkit.org/show_bug.cgi?id=280210). Disabling explicit
+    // sync via the Nvidia driver avoids the crash without disabling hardware acceleration.
     #[cfg(target_os = "linux")]
-    if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+    if std::env::var("__NV_DISABLE_EXPLICIT_SYNC").is_err()
+        && std::env::var("WAYLAND_DISPLAY").is_ok()
+        && std::path::Path::new("/sys/module/nvidia").exists()
+    {
         // SAFETY: called before any threads are spawned.
-        unsafe { std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1") };
+        unsafe { std::env::set_var("__NV_DISABLE_EXPLICIT_SYNC", "1") };
     }
 
     tauri_app_client_lib::run();


### PR DESCRIPTION
## Summary

On Nvidia GPUs running Wayland, WebKit2GTK's DMA-BUF renderer triggers a protocol error (71) due to an explicit sync conflict between WebKit's ANGLE implementation and Nvidia's egl-wayland library. This sets \`__NV_DISABLE_EXPLICIT_SYNC=1\` only when Nvidia drivers are active and a Wayland display is present, avoiding the crash without disabling hardware acceleration.

## Submission

- [x] This PR is a bug fix or small-scope improvement.
- [ ] If this PR is not a bug fix or small-scope improvement, I linked an approved feedback item below.
- [x] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [x] I tested this change locally.
- [ ] I added or updated tests when reasonable.

Approved feedback item (required if not a bug fix or small-scope improvement):

<!-- https://yaak.app/feedback/... -->

## Related

WebKit upstream bug: https://bugs.webkit.org/show_bug.cgi?id=280210