### PR TITLE
Fix spell correction prompt showing

### DIFF
--- a/apps/yaak-client/components/CookieDialog.tsx
+++ b/apps/yaak-client/components/CookieDialog.tsx
@@ -130,7 +130,7 @@ export const CookieDialog = ({ cookieJarId }: Props) => {
       return key !== nextCookieKey;
     });
 
-    patchModel(cookieJar, { cookies: [...nextCookies, nextCookie] });
+    void patchModel(cookieJar, { cookies: [...nextCookies, nextCookie] });
     setSelectedCookieKey(nextCookieKey);
     setEditingCookieKey(null);
     setDraftCookie(null);
@@ -210,7 +210,7 @@ export const CookieDialog = ({ cookieJarId }: Props) => {
                           setEditingCookieKey(null);
                           setDraftCookie(null);
                           setDraftExpiresInput("");
-                          patchModel(cookieJar, { cookies: [] });
+                          void patchModel(cookieJar, { cookies: [] });
                         }}
                       />
                     </TableHeaderCell>
@@ -276,7 +276,7 @@ export const CookieDialog = ({ cookieJarId }: Props) => {
                                 setDraftCookie(null);
                                 setDraftExpiresInput("");
                               }
-                              patchModel(cookieJar, {
+                              void patchModel(cookieJar, {
                                 cookies: cookieJar.cookies.filter(
                                   (c2: Cookie) => cookieKey(c2) !== key,
                                 ),

--- a/apps/yaak-client/components/CookieDialog.tsx
+++ b/apps/yaak-client/components/CookieDialog.tsx
@@ -570,6 +570,8 @@ function CookieTextInput({
   return (
     <input
       autoFocus={autoFocus}
+      autoCapitalize="off"
+      autoCorrect="off"
       className={cookieInputClassName}
       disabled={disabled}
       onChange={(event) => onChange(event.target.value)}
@@ -585,6 +587,8 @@ function CookieTextInput({
 function CookieTextarea({ onChange, value }: { onChange: (value: string) => void; value: string }) {
   return (
     <textarea
+      autoCapitalize="off"
+      autoCorrect="off"
       className={classNames(cookieInputClassName, "min-h-[5rem] resize-y")}
       onChange={(event) => onChange(event.target.value)}
       value={value}

--- a/apps/yaak-client/components/WorkspaceSettingsDialog.tsx
+++ b/apps/yaak-client/components/WorkspaceSettingsDialog.tsx
@@ -1,5 +1,5 @@
 import { patchModel, workspaceMetasAtom, workspacesAtom } from "@yaakapp-internal/models";
-import { Banner, HStack, InlineCode, VStack } from "@yaakapp-internal/ui";
+import { Banner, HStack, InlineCode } from "@yaakapp-internal/ui";
 import { useAtomValue } from "jotai";
 import { useAuthTab } from "../hooks/useAuthTab";
 import { useHeadersTab } from "../hooks/useHeadersTab";

--- a/apps/yaak-client/components/core/Editor/Editor.tsx
+++ b/apps/yaak-client/components/core/Editor/Editor.tsx
@@ -580,6 +580,10 @@ function getExtensions({
 
   return [
     ...baseExtensions, // Must be first
+    EditorView.contentAttributes.of({
+      autocapitalize: "off",
+      autocorrect: "off",
+    }),
     EditorView.domEventHandlers({
       focus: () => {
         onFocus.current?.();

--- a/apps/yaak-client/components/core/KeyValueRow.tsx
+++ b/apps/yaak-client/components/core/KeyValueRow.tsx
@@ -55,6 +55,8 @@ export function KeyValueRow({
   const textToCopy =
     copyText ??
     (typeof children === "string" || typeof children === "number" ? `${children}` : null);
+  const copyTitle =
+    typeof label === "string" || typeof label === "number" ? `Copy ${label}` : "Copy value";
   const resolvedRightSlot =
     rightSlot ??
     (enableCopy && textToCopy != null ? (
@@ -62,7 +64,7 @@ export function KeyValueRow({
         text={textToCopy}
         className="text-text-subtle"
         size="2xs"
-        title={`Copy ${label}`}
+        title={copyTitle}
         iconSize="sm"
       />
     ) : null);

--- a/apps/yaak-client/components/git/FileHistoryDialog.tsx
+++ b/apps/yaak-client/components/git/FileHistoryDialog.tsx
@@ -1,6 +1,6 @@
 import { useGitFileDiffForCommit, useGitLog, useGitMutations } from "@yaakapp-internal/git";
 import type { GitCommit } from "@yaakapp-internal/git";
-import { InlineCode, SplitLayout } from "@yaakapp-internal/ui";
+import { SplitLayout } from "@yaakapp-internal/ui";
 import classNames from "classnames";
 import { formatDistanceToNowStrict } from "date-fns";
 import { useCallback, useEffect, useMemo, useState } from "react";

--- a/apps/yaak-client/components/git/GitCommitDialog.tsx
+++ b/apps/yaak-client/components/git/GitCommitDialog.tsx
@@ -8,7 +8,7 @@ import type {
   WebsocketRequest,
   Workspace,
 } from "@yaakapp-internal/models";
-import { Banner, HStack, Icon, IconButton, InlineCode, SplitLayout } from "@yaakapp-internal/ui";
+import { Banner, HStack, Icon, InlineCode, SplitLayout } from "@yaakapp-internal/ui";
 import classNames from "classnames";
 import { useCallback, useMemo, useState } from "react";
 import { modelToYaml } from "../../lib/diffYaml";

--- a/packages/ui/src/components/tree/TreeItem.tsx
+++ b/packages/ui/src/components/tree/TreeItem.tsx
@@ -364,6 +364,8 @@ function TreeItem_<T extends { id: string }>({
                   ref={handleEditFocus}
                   defaultValue={defaultValue}
                   placeholder={placeholder}
+                  autoCapitalize="off"
+                  autoCorrect="off"
                   className="bg-transparent outline-none w-full cursor-text"
                   onBlur={handleEditBlur}
                   onKeyDown={handleEditKeyDown}


### PR DESCRIPTION
Fixes the macOS correction popover appearing while typing request names and other technical text by disabling autocorrect and autocapitalization where those values are entered. Spellcheck is left enabled so users can still get red squiggles without the intrusive suggestion bubble.

- Adds autocorrect/autocapitalization-off attributes to CodeMirror-backed text inputs.
- Disables autocorrect/autocapitalization for inline tree rename fields.
- Applies the same behavior to cookie text fields.
- Cleans up existing lint warnings from unused imports, a ReactNode tooltip title, and intentionally ignored cookie update promises.
- Validated with `npm run lint`.

https://yaak.app/feedback/posts/fix-spell-correction-prompt-showing