### PR TITLE
Support string-based `url.path` in Postman importer.

### DIFF
--- a/plugins/importer-postman/src/index.ts
+++ b/plugins/importer-postman/src/index.ts
@@ -180,8 +180,12 @@ function convertUrl(rawUrl: unknown): Pick<HttpRequest, "url" | "urlParameters">
     v += `:${url.port}`;
   }
 
-  if ("path" in url && Array.isArray(url.path) && url.path.length > 0) {
-    v += `/${Array.isArray(url.path) ? url.path.join("/") : url.path}`;
+  if ("path" in url) {
+    if (Array.isArray(url.path) && url.path.length > 0) {
+      v += `/${url.path.join("/")}`;
+    } else if (typeof url.path === "string" && url.path.length > 0) {
+      v += `/${url.path.replace(/^\//, "")}`;
+    }
   }
 
   const params: HttpUrlParameter[] = [];

--- a/plugins/importer-postman/tests/index.test.ts
+++ b/plugins/importer-postman/tests/index.test.ts
@@ -57,4 +57,34 @@ describe("importer-postman", () => {
       }),
     ]);
   });
+
+  test("Imports url.path when it is a string instead of an array", () => {
+    const result = convertPostman(
+      JSON.stringify({
+        info: {
+          name: "String Path Test",
+          schema: "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        },
+        item: [
+          {
+            name: "String Path",
+            request: {
+              method: "GET",
+              url: {
+                host: ["example", "com"],
+                path: "foo/bar",
+              },
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(result?.resources.httpRequests).toEqual([
+      expect.objectContaining({
+        name: "String Path",
+        url: "example.com/foo/bar",
+      }),
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

Old postman collections have the url path as strings like `api/v3/users`, while newer collections have arrays like `['api','v3','users']`. The yaak importer-postman plugin silently dropped the string version, making all paths empty.

This fix explicitly handles both types.

## Submission

- [x] This PR is a bug fix.
- [ ] If this PR is not a bug fix, I linked the feedback item where @gschier explicitly gave me permission to work on it.
- [x] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [x] I tested this change locally.
- [x] I added or updated tests when reasonable.
- [x] I added screenshots or recordings for UI changes when reasonable.

