### PR TITLE
[codex] Use generated release notes placeholder

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -185,7 +185,7 @@ jobs:
           tauriScript: "node ../../node_modules/@tauri-apps/cli/tauri.js"
           tagName: "v__VERSION__"
           releaseName: "Release __VERSION__"
-          releaseBody: "[Changelog __VERSION__](https://yaak.app/blog/__VERSION__)"
+          releaseBody: "<!-- generated-by-yaak-releases -->"
           releaseDraft: true
           prerelease: true
           projectPath: ./crates-tauri/yaak-app-client


### PR DESCRIPTION
## What changed

The app release workflow now seeds draft GitHub releases with `<!-- generated-by-yaak-releases -->` instead of a placeholder changelog link.

## Why

The website release tooling only replaces GitHub release bodies that are empty or already marked as generated. The previous changelog link looked like manual release notes, so `release_ship_beta` preserved it and skipped the generated notes update.

## Impact

Future beta and stable release shipping can replace the draft release body with the website-formatted generated notes.

## Validation

- `git diff --check -- .github/workflows/release-app.yml`

No tags were created or changed.