### PR TITLE
Detect and surface plugin runtime crashes

### DIFF
--- a/crates-tauri/yaak-app-client/src/plugins_ext.rs
+++ b/crates-tauri/yaak-app-client/src/plugins_ext.rs
@@ -28,7 +28,7 @@ use yaak_plugins::api::{
     PluginNameVersion, PluginSearchResponse, PluginUpdatesResponse, check_plugin_updates,
     search_plugins,
 };
-use yaak_plugins::events::PluginContext;
+use yaak_plugins::events::{Color, PluginContext, ShowToastRequest};
 use yaak_plugins::install::{delete_and_uninstall, download_and_install};
 use yaak_plugins::manager::PluginManager;
 use yaak_plugins::plugin_meta::get_plugin_meta;
@@ -314,6 +314,28 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                 )
                 .await
                 .expect("Failed to start plugin runtime");
+
+                // Surface unexpected runtime crashes (after startup) to the user
+                let mut crash_rx = manager
+                    .take_runtime_crash_rx()
+                    .await
+                    .expect("runtime crash receiver already taken");
+                let app_handle_crash = app_handle_clone.clone();
+                tauri::async_runtime::spawn(async move {
+                    if let Some(status) = crash_rx.recv().await {
+                        let _ = app_handle_crash.emit(
+                            "show_toast",
+                            ShowToastRequest {
+                                message: format!(
+                                    "Plugin runtime crashed ({status}). Plugins won't work until Yaak is restarted"
+                                ),
+                                color: Some(Color::Danger),
+                                icon: None,
+                                timeout: None,
+                            },
+                        );
+                    }
+                });
 
                 app_handle_clone.manage(manager);
             });

--- a/crates-tauri/yaak-app-client/src/plugins_ext.rs
+++ b/crates-tauri/yaak-app-client/src/plugins_ext.rs
@@ -315,14 +315,12 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                 .await
                 .expect("Failed to start plugin runtime");
 
-                // Surface unexpected runtime crashes (after startup) to the user
-                let mut crash_rx = manager
-                    .take_runtime_crash_rx()
-                    .await
-                    .expect("runtime crash receiver already taken");
+                // Surface unexpected runtime crashes to the user
+                let mut crash_rx = manager.runtime_crash_rx();
                 let app_handle_crash = app_handle_clone.clone();
                 tauri::async_runtime::spawn(async move {
-                    if let Some(status) = crash_rx.recv().await {
+                    if crash_rx.wait_for(|status| status.is_some()).await.is_ok() {
+                        let status = crash_rx.borrow().clone().unwrap_or_default();
                         // The crash may happen during startup, before any window or
                         // frontend listener exists — wait so the toast isn't lost
                         while app_handle_crash.webview_windows().is_empty() {

--- a/crates-tauri/yaak-app-client/src/plugins_ext.rs
+++ b/crates-tauri/yaak-app-client/src/plugins_ext.rs
@@ -323,12 +323,16 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                 let app_handle_crash = app_handle_clone.clone();
                 tauri::async_runtime::spawn(async move {
                     if let Some(status) = crash_rx.recv().await {
+                        // The crash may happen during startup, before any window or
+                        // frontend listener exists — wait so the toast isn't lost
+                        while app_handle_crash.webview_windows().is_empty() {
+                            tokio::time::sleep(Duration::from_millis(500)).await;
+                        }
+                        tokio::time::sleep(Duration::from_secs(3)).await;
                         let _ = app_handle_crash.emit(
                             "show_toast",
                             ShowToastRequest {
-                                message: format!(
-                                    "Plugin runtime crashed ({status}). Plugins won't work until Yaak is restarted"
-                                ),
+                                message: format!("Plugin runtime crashed ({status})"),
                                 color: Some(Color::Danger),
                                 icon: None,
                                 timeout: None,

--- a/crates/yaak-plugins/src/manager.rs
+++ b/crates/yaak-plugins/src/manager.rs
@@ -52,9 +52,9 @@ pub struct PluginManager {
     dev_mode: bool,
     /// Errors from plugin initialization, retrievable once via `take_init_errors`.
     init_errors: Arc<Mutex<Vec<(String, String)>>>,
-    /// Fires with the exit status if the runtime dies unexpectedly after startup,
-    /// retrievable once via `take_runtime_crash_rx`.
-    runtime_crash_rx: Arc<Mutex<Option<mpsc::Receiver<String>>>>,
+    /// Set to the exit status if the runtime dies unexpectedly, observable
+    /// via `runtime_crash_rx`.
+    runtime_crash_rx: tokio::sync::watch::Receiver<Option<String>>,
 }
 
 /// Callback for plugin initialization events (e.g., toast notifications)
@@ -86,19 +86,12 @@ impl PluginManager {
 
         let (client_disconnect_tx, mut client_disconnect_rx) = mpsc::channel(128);
         let (client_connect_tx, mut client_connect_rx) = tokio::sync::watch::channel(false);
-        let (unexpected_exit_tx, mut unexpected_exit_rx) = mpsc::channel::<String>(1);
-        let (runtime_crash_tx, runtime_crash_rx) = mpsc::channel::<String>(1);
-        let (runtime_dead_tx, runtime_dead_rx) = tokio::sync::watch::channel(false);
-
-        // The app is still usable without the plugin runtime (just missing
-        // features), so an unexpected exit unblocks startup and is surfaced
-        // to the user rather than taking the app down.
-        tokio::spawn(async move {
-            if let Some(status) = unexpected_exit_rx.recv().await {
-                let _ = runtime_dead_tx.send(true);
-                let _ = runtime_crash_tx.send(status).await;
-            }
-        });
+        // Set to the exit status if the runtime dies unexpectedly. The app is
+        // still usable without the plugin runtime (just missing features), so
+        // this unblocks startup and is surfaced to the user rather than
+        // taking the app down.
+        let (unexpected_exit_tx, unexpected_exit_rx) =
+            tokio::sync::watch::channel::<Option<String>>(None);
         let ws_service =
             PluginRuntimeServerWebsocket::new(events_tx, client_disconnect_tx, client_connect_tx);
 
@@ -112,7 +105,7 @@ impl PluginManager {
             installed_plugin_dir,
             dev_mode,
             init_errors: Default::default(),
-            runtime_crash_rx: Arc::new(Mutex::new(Some(runtime_crash_rx))),
+            runtime_crash_rx: unexpected_exit_rx.clone(),
         };
 
         // Forward events to subscribers
@@ -150,7 +143,7 @@ impl PluginManager {
         let addr = listener.local_addr().expect("Failed to get local address");
 
         // 1. Wait for the Node.js runtime to connect, or for it to die trying
-        let mut init_dead_rx = runtime_dead_rx.clone();
+        let mut init_dead_rx = unexpected_exit_rx.clone();
         let init_plugins_task = tokio::spawn(async move {
             tokio::select! {
                 result = client_connect_rx.changed() => match result {
@@ -163,7 +156,7 @@ impl PluginManager {
                         warn!("Failed to receive from client connection rx {e:?}");
                     }
                 },
-                _ = init_dead_rx.wait_for(|dead| *dead) => {
+                _ = init_dead_rx.wait_for(|status| status.is_some()) => {
                     warn!("Plugin runtime exited before connecting; continuing without plugins");
                 }
             }
@@ -188,7 +181,7 @@ impl PluginManager {
         info!("Waiting for plugins to initialize");
         init_plugins_task.await.map_err(|e| PluginErr(e.to_string()))?;
 
-        if *runtime_dead_rx.borrow() {
+        if unexpected_exit_rx.borrow().is_some() {
             warn!("Skipping plugin initialization because the runtime is not running");
             return Ok(plugin_manager);
         }
@@ -230,10 +223,10 @@ impl PluginManager {
         std::mem::take(&mut *self.init_errors.lock().await)
     }
 
-    /// Take the receiver that fires with the exit status if the plugin runtime
-    /// dies unexpectedly after startup. Can only be taken once.
-    pub async fn take_runtime_crash_rx(&self) -> Option<mpsc::Receiver<String>> {
-        self.runtime_crash_rx.lock().await.take()
+    /// A receiver that is set to the exit status if the plugin runtime dies
+    /// unexpectedly.
+    pub fn runtime_crash_rx(&self) -> tokio::sync::watch::Receiver<Option<String>> {
+        self.runtime_crash_rx.clone()
     }
 
     /// Get the vendored plugin directory path (resolves dev mode path if applicable)

--- a/crates/yaak-plugins/src/manager.rs
+++ b/crates/yaak-plugins/src/manager.rs
@@ -28,6 +28,7 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::fs::read_dir;
 use tokio::net::TcpListener;
@@ -52,6 +53,9 @@ pub struct PluginManager {
     dev_mode: bool,
     /// Errors from plugin initialization, retrievable once via `take_init_errors`.
     init_errors: Arc<Mutex<Vec<(String, String)>>>,
+    /// Fires with the exit status if the runtime dies unexpectedly after startup,
+    /// retrievable once via `take_runtime_crash_rx`.
+    runtime_crash_rx: Arc<Mutex<Option<mpsc::Receiver<String>>>>,
 }
 
 /// Callback for plugin initialization events (e.g., toast notifications)
@@ -83,6 +87,24 @@ impl PluginManager {
 
         let (client_disconnect_tx, mut client_disconnect_rx) = mpsc::channel(128);
         let (client_connect_tx, mut client_connect_rx) = tokio::sync::watch::channel(false);
+        let (unexpected_exit_tx, mut unexpected_exit_rx) = mpsc::channel::<String>(1);
+        let (runtime_crash_tx, runtime_crash_rx) = mpsc::channel::<String>(1);
+        let runtime_connected = Arc::new(AtomicBool::new(false));
+
+        // An unexpected runtime exit before it ever connects means the app can
+        // never become functional — abort loudly instead of hanging on startup.
+        // After that, report it so the app can show a user-facing error.
+        let runtime_connected_for_exit = runtime_connected.clone();
+        tokio::spawn(async move {
+            if let Some(status) = unexpected_exit_rx.recv().await {
+                if runtime_connected_for_exit.load(Ordering::SeqCst) {
+                    let _ = runtime_crash_tx.send(status).await;
+                } else {
+                    error!("Plugin runtime exited during startup; aborting");
+                    std::process::exit(1);
+                }
+            }
+        });
         let ws_service =
             PluginRuntimeServerWebsocket::new(events_tx, client_disconnect_tx, client_connect_tx);
 
@@ -96,6 +118,7 @@ impl PluginManager {
             installed_plugin_dir,
             dev_mode,
             init_errors: Default::default(),
+            runtime_crash_rx: Arc::new(Mutex::new(Some(runtime_crash_rx))),
         };
 
         // Forward events to subscribers
@@ -137,6 +160,7 @@ impl PluginManager {
             match client_connect_rx.changed().await {
                 Ok(_) => {
                     info!("Plugin runtime client connected!");
+                    runtime_connected.store(true, Ordering::SeqCst);
                     // Note: initialize_all_plugins is now called separately by the app
                     // after setting up the plugin list
                 }
@@ -159,6 +183,7 @@ impl PluginManager {
             addr,
             &kill_server_rx,
             killed_tx,
+            unexpected_exit_tx,
         )
         .await?;
         info!("Waiting for plugins to initialize");
@@ -199,6 +224,12 @@ impl PluginManager {
     /// Returns a list of `(plugin_directory, error_message)` pairs.
     pub async fn take_init_errors(&self) -> Vec<(String, String)> {
         std::mem::take(&mut *self.init_errors.lock().await)
+    }
+
+    /// Take the receiver that fires with the exit status if the plugin runtime
+    /// dies unexpectedly after startup. Can only be taken once.
+    pub async fn take_runtime_crash_rx(&self) -> Option<mpsc::Receiver<String>> {
+        self.runtime_crash_rx.lock().await.take()
     }
 
     /// Get the vendored plugin directory path (resolves dev mode path if applicable)

--- a/crates/yaak-plugins/src/manager.rs
+++ b/crates/yaak-plugins/src/manager.rs
@@ -28,7 +28,6 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::fs::read_dir;
 use tokio::net::TcpListener;
@@ -89,20 +88,15 @@ impl PluginManager {
         let (client_connect_tx, mut client_connect_rx) = tokio::sync::watch::channel(false);
         let (unexpected_exit_tx, mut unexpected_exit_rx) = mpsc::channel::<String>(1);
         let (runtime_crash_tx, runtime_crash_rx) = mpsc::channel::<String>(1);
-        let runtime_connected = Arc::new(AtomicBool::new(false));
+        let (runtime_dead_tx, runtime_dead_rx) = tokio::sync::watch::channel(false);
 
-        // An unexpected runtime exit before it ever connects means the app can
-        // never become functional — abort loudly instead of hanging on startup.
-        // After that, report it so the app can show a user-facing error.
-        let runtime_connected_for_exit = runtime_connected.clone();
+        // The app is still usable without the plugin runtime (just missing
+        // features), so an unexpected exit unblocks startup and is surfaced
+        // to the user rather than taking the app down.
         tokio::spawn(async move {
             if let Some(status) = unexpected_exit_rx.recv().await {
-                if runtime_connected_for_exit.load(Ordering::SeqCst) {
-                    let _ = runtime_crash_tx.send(status).await;
-                } else {
-                    error!("Plugin runtime exited during startup; aborting");
-                    std::process::exit(1);
-                }
+                let _ = runtime_dead_tx.send(true);
+                let _ = runtime_crash_tx.send(status).await;
             }
         });
         let ws_service =
@@ -155,17 +149,22 @@ impl PluginManager {
         let listener = TcpListener::bind(listen_addr).await.expect("Failed to bind TCP listener");
         let addr = listener.local_addr().expect("Failed to get local address");
 
-        // 1. Wait for Node.js runtime to connect
+        // 1. Wait for the Node.js runtime to connect, or for it to die trying
+        let mut init_dead_rx = runtime_dead_rx.clone();
         let init_plugins_task = tokio::spawn(async move {
-            match client_connect_rx.changed().await {
-                Ok(_) => {
-                    info!("Plugin runtime client connected!");
-                    runtime_connected.store(true, Ordering::SeqCst);
-                    // Note: initialize_all_plugins is now called separately by the app
-                    // after setting up the plugin list
-                }
-                Err(e) => {
-                    warn!("Failed to receive from client connection rx {e:?}");
+            tokio::select! {
+                result = client_connect_rx.changed() => match result {
+                    Ok(_) => {
+                        info!("Plugin runtime client connected!");
+                        // Note: initialize_all_plugins is now called separately by the app
+                        // after setting up the plugin list
+                    }
+                    Err(e) => {
+                        warn!("Failed to receive from client connection rx {e:?}");
+                    }
+                },
+                _ = init_dead_rx.wait_for(|dead| *dead) => {
+                    warn!("Plugin runtime exited before connecting; continuing without plugins");
                 }
             }
         });
@@ -188,6 +187,11 @@ impl PluginManager {
         .await?;
         info!("Waiting for plugins to initialize");
         init_plugins_task.await.map_err(|e| PluginErr(e.to_string()))?;
+
+        if *runtime_dead_rx.borrow() {
+            warn!("Skipping plugin initialization because the runtime is not running");
+            return Ok(plugin_manager);
+        }
 
         let bundled_dirs = plugin_manager.list_bundled_plugin_dirs().await?;
         let db = query_manager.connect();

--- a/crates/yaak-plugins/src/nodejs.rs
+++ b/crates/yaak-plugins/src/nodejs.rs
@@ -16,7 +16,7 @@ use yaak_common::command::new_xplatform_command;
 /// * `addr` - Socket address for the plugin runtime to connect to
 /// * `kill_rx` - Channel to signal shutdown
 /// * `killed_tx` - Notified once the runtime is killed after a shutdown signal
-/// * `unexpected_exit_tx` - Notified with the exit status if the runtime exits
+/// * `unexpected_exit_tx` - Set to the exit status if the runtime exits
 ///   without being asked to
 pub async fn start_nodejs_plugin_runtime(
     node_bin_path: &Path,
@@ -24,7 +24,7 @@ pub async fn start_nodejs_plugin_runtime(
     addr: SocketAddr,
     kill_rx: &Receiver<bool>,
     killed_tx: oneshot::Sender<()>,
-    unexpected_exit_tx: tokio::sync::mpsc::Sender<String>,
+    unexpected_exit_tx: tokio::sync::watch::Sender<Option<String>>,
 ) -> Result<()> {
     // HACK: Remove UNC prefix for Windows paths to pass to sidecar
     let plugin_runtime_main_str =
@@ -78,7 +78,7 @@ pub async fn start_nodejs_plugin_runtime(
             status = child.wait() => {
                 let status = status.map(|s| s.to_string()).unwrap_or_else(|e| e.to_string());
                 error!("Plugin runtime exited unexpectedly ({status})");
-                let _ = unexpected_exit_tx.send(status).await;
+                let _ = unexpected_exit_tx.send(Some(status));
             }
             closed = async { kill_rx.wait_for(|b| *b == true).await.is_err() } => {
                 if closed {

--- a/crates/yaak-plugins/src/nodejs.rs
+++ b/crates/yaak-plugins/src/nodejs.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use log::{info, warn};
+use log::{error, info, warn};
 use std::net::SocketAddr;
 use std::path::Path;
 use std::process::Stdio;
@@ -15,12 +15,16 @@ use yaak_common::command::new_xplatform_command;
 /// * `plugin_runtime_main` - Path to the plugin runtime index.cjs
 /// * `addr` - Socket address for the plugin runtime to connect to
 /// * `kill_rx` - Channel to signal shutdown
+/// * `killed_tx` - Notified once the runtime is killed after a shutdown signal
+/// * `unexpected_exit_tx` - Notified with the exit status if the runtime exits
+///   without being asked to
 pub async fn start_nodejs_plugin_runtime(
     node_bin_path: &Path,
     plugin_runtime_main: &Path,
     addr: SocketAddr,
     kill_rx: &Receiver<bool>,
     killed_tx: oneshot::Sender<()>,
+    unexpected_exit_tx: tokio::sync::mpsc::Sender<String>,
 ) -> Result<()> {
     // HACK: Remove UNC prefix for Windows paths to pass to sidecar
     let plugin_runtime_main_str =
@@ -65,18 +69,29 @@ pub async fn start_nodejs_plugin_runtime(
         });
     }
 
-    // Handle kill signal
+    // Wait for either an explicit kill signal or the child exiting on its own.
+    // An unexpected exit is reported to the caller, which decides whether to
+    // abort startup or surface a user-facing error.
     let mut kill_rx = kill_rx.clone();
     tokio::spawn(async move {
-        if kill_rx.wait_for(|b| *b == true).await.is_err() {
-            warn!("Kill channel closed before explicit shutdown; terminating plugin runtime");
+        tokio::select! {
+            status = child.wait() => {
+                let status = status.map(|s| s.to_string()).unwrap_or_else(|e| e.to_string());
+                error!("Plugin runtime exited unexpectedly ({status})");
+                let _ = unexpected_exit_tx.send(status).await;
+            }
+            closed = async { kill_rx.wait_for(|b| *b == true).await.is_err() } => {
+                if closed {
+                    warn!("Kill channel closed before explicit shutdown; terminating plugin runtime");
+                }
+                info!("Killing plugin runtime");
+                if let Err(e) = child.kill().await {
+                    warn!("Failed to kill plugin runtime: {e}");
+                }
+                info!("Killed plugin runtime");
+                let _ = killed_tx.send(());
+            }
         }
-        info!("Killing plugin runtime");
-        if let Err(e) = child.kill().await {
-            warn!("Failed to kill plugin runtime: {e}");
-        }
-        info!("Killed plugin runtime");
-        let _ = killed_tx.send(());
     });
 
     Ok(())


### PR DESCRIPTION
## What

The plugin runtime child process was never monitored after spawning. If it died, the app hung forever at "Waiting for plugins to initialize" with nothing in the logs and no window shown.

Hit in dev when macOS 27 killed the vendored node binary for an invalid code signature — a silent SIGKILL at exec, so the runtime produced zero output.

## How

The app is usable without the plugin runtime (just with missing features), so a runtime crash never takes the app down:

- `nodejs.rs` — the spawn task now `select!`s between the kill signal and `child.wait()`, logging `Plugin runtime exited unexpectedly (<status>)` and reporting the exit through a channel
- `manager.rs` — a runtime exit unblocks startup (plugin initialization is skipped) and the exit status is exposed via `take_runtime_crash_rx()`
- `plugins_ext.rs` — a persistent danger toast shows the crash; if it happens during startup, the toast waits for a window to exist before showing

## Testing

- Stripped the signature from the vendored `yaaknode` (reproduces the SIGKILL): app starts plugin-less, logs the error, and shows the toast
- `kill -9` on the runtime while the app is running: toast appears, app stays up