### PR TITLE
Batch streamed request body history into full-size chunks

### DIFF
--- a/crates/yaak/src/send.rs
+++ b/crates/yaak/src/send.rs
@@ -949,14 +949,24 @@ async fn persist_request_body_stream(
 ) -> std::result::Result<usize, String> {
     let mut chunk_index: i32 = 0;
     let mut total_bytes = 0usize;
+
+    // Stream reads arrive in small (eg. 8-16 KiB) pieces, so accumulate them into
+    // full-size chunks to avoid thousands of tiny inserts for large bodies
+    let mut buf: Vec<u8> = Vec::with_capacity(REQUEST_BODY_CHUNK_SIZE);
     while let Some(data) = rx.recv().await {
         total_bytes += data.len();
-        if data.is_empty() {
-            continue;
+        buf.extend_from_slice(&data);
+        while buf.len() >= REQUEST_BODY_CHUNK_SIZE {
+            let data = buf.drain(..REQUEST_BODY_CHUNK_SIZE).collect();
+            let chunk = BodyChunk::new(&body_id, chunk_index, data);
+            blob_manager.connect().insert_chunk(&chunk).map_err(|e| e.to_string())?;
+            chunk_index += 1;
         }
-        let chunk = BodyChunk::new(&body_id, chunk_index, data);
+    }
+
+    if !buf.is_empty() {
+        let chunk = BodyChunk::new(&body_id, chunk_index, buf);
         blob_manager.connect().insert_chunk(&chunk).map_err(|e| e.to_string())?;
-        chunk_index += 1;
     }
 
     Ok(total_bytes)


### PR DESCRIPTION
Follow-up to #498. Streamed request bodies were persisted one row per network read (~8-16 KiB), so a large upload produced thousands of tiny SQLite inserts — the reason body-history capture lagged seconds behind the response.

`persist_request_body_stream` now accumulates reads into the same 1 MB `REQUEST_BODY_CHUNK_SIZE` chunks the in-memory body path uses, flushing the remainder when the stream ends. An 88 MB upload drops from ~10k inserts to ~89.

Connection checkout stays per-insert (rather than held for the stream's lifetime) so long uploads can't starve the blob pool.