### PR TITLE
Fix keyboard shortcut help layout

### DIFF
--- a/apps/yaak-client/components/core/HotkeyList.test.tsx
+++ b/apps/yaak-client/components/core/HotkeyList.test.tsx
@@ -1,0 +1,25 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test, vi } from "vite-plus/test";
+import type { HotkeyAction } from "../../hooks/useHotKey";
+import { HotkeyList } from "./HotkeyList";
+
+vi.mock("./Hotkey", () => ({
+  Hotkey: ({ action }: { action: HotkeyAction }) =>
+    action === "sidebar.selected.move" ? null : <span>{action}</span>,
+}));
+
+vi.mock("./HotkeyLabel", () => ({
+  HotkeyLabel: ({ action }: { action: HotkeyAction }) => <span>{action}</span>,
+}));
+
+describe("HotkeyList", () => {
+  test("keeps a grid cell for actions without a shortcut", () => {
+    const markup = renderToStaticMarkup(
+      <HotkeyList hotkeys={["sidebar.selected.move", "request.send"]} />,
+    );
+
+    expect(markup).toContain(
+      '<span>sidebar.selected.move</span><div class="ml-4"></div><span>request.send</span>',
+    );
+  });
+});

--- a/apps/yaak-client/components/core/HotkeyList.tsx
+++ b/apps/yaak-client/components/core/HotkeyList.tsx
@@ -18,6 +18,7 @@ export const HotkeyList = ({ hotkeys, bottomSlot, className }: Props) => {
         {hotkeys.map((hotkey) => (
           <Fragment key={hotkey}>
             <HotkeyLabel className="truncate" action={hotkey} />
+            {/* Keep this grid cell when Hotkey renders nothing so later rows stay aligned. */}
             <div className="ml-4">
               <Hotkey action={hotkey} />
             </div>

--- a/apps/yaak-client/components/core/HotkeyList.tsx
+++ b/apps/yaak-client/components/core/HotkeyList.tsx
@@ -18,7 +18,9 @@ export const HotkeyList = ({ hotkeys, bottomSlot, className }: Props) => {
         {hotkeys.map((hotkey) => (
           <Fragment key={hotkey}>
             <HotkeyLabel className="truncate" action={hotkey} />
-            <Hotkey className="ml-4" action={hotkey} />
+            <div className="ml-4">
+              <Hotkey action={hotkey} />
+            </div>
           </Fragment>
         ))}
         {bottomSlot}


### PR DESCRIPTION
Fixes shortcut rows shifting after an action with no configured binding.

* Give every shortcut action a stable value grid cell even when `Hotkey` renders nothing
* Add regression coverage for an unbound action followed by a bound action

https://yaak.app/feedback/posts/broken-keyboard-shortcuts-modal-formatting