### PR TITLE
Fix inline rename during IME composition

### DIFF
--- a/packages/ui/src/components/tree/TreeItem.tsx
+++ b/packages/ui/src/components/tree/TreeItem.tsx
@@ -20,6 +20,7 @@ import {
 } from "./context";
 import type { TreeNode } from "./common";
 import { getNodeKey } from "./common";
+import { isImeCompositionEvent } from "./keyboard";
 import type { TreeProps } from "./Tree";
 import { TreeIndentGuide } from "./TreeIndentGuide";
 
@@ -170,6 +171,8 @@ function TreeItem_<T extends { id: string }>({
   const handleEditKeyDown = useCallback(
     async (e: ReactKeyboardEvent<HTMLInputElement>) => {
       e.stopPropagation(); // Don't trigger other tree keys (like arrows)
+      if (isImeCompositionEvent(e.nativeEvent)) return;
+
       switch (e.key) {
         case "Enter":
           if (editing) {

--- a/packages/ui/src/components/tree/keyboard.test.ts
+++ b/packages/ui/src/components/tree/keyboard.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "vite-plus/test";
+import { isImeCompositionEvent } from "./keyboard";
+
+describe("isImeCompositionEvent", () => {
+  test("detects an active standards-based composition", () => {
+    expect(isImeCompositionEvent({ isComposing: true, keyCode: 13 })).toBe(true);
+  });
+
+  test("detects the Safari/WebKit key code fallback", () => {
+    expect(isImeCompositionEvent({ isComposing: false, keyCode: 229 })).toBe(true);
+  });
+
+  test("does not classify an ordinary Enter keydown as composition", () => {
+    expect(isImeCompositionEvent({ isComposing: false, keyCode: 13 })).toBe(false);
+  });
+
+  test("does not classify an ordinary Escape keydown as composition", () => {
+    expect(isImeCompositionEvent({ isComposing: false, keyCode: 27 })).toBe(false);
+  });
+});

--- a/packages/ui/src/components/tree/keyboard.ts
+++ b/packages/ui/src/components/tree/keyboard.ts
@@ -1,0 +1,7 @@
+export type ImeKeyboardEvent = Pick<KeyboardEvent, "isComposing" | "keyCode">;
+
+export function isImeCompositionEvent(event: ImeKeyboardEvent): boolean {
+  // Safari can clear `isComposing` on the keydown that finishes composition.
+  // `229` is retained as the compatibility signal that an IME is processing it.
+  return event.isComposing || event.keyCode === 229;
+}


### PR DESCRIPTION
## Summary

Fix sidebar request and folder renaming closing when Enter is used to accept a CJK IME candidate. IME keydowns are ignored using the standards-based `isComposing` flag with the WebKit `keyCode === 229` compatibility fallback, while ordinary Enter and Escape behavior remains unchanged.

## Root cause

The shared inline-rename input treated every Enter keydown as a submit action, including Enter events consumed by an active IME to confirm a candidate. WebKit can report the candidate-confirming keydown after composition has ended, so the compatibility fallback is needed in addition to `isComposing`.

## Submission

- [x] This PR is a bug fix.
- [ ] If this PR is not a bug fix, I linked the feedback item where @gschier explicitly gave me permission to work on it.
- [x] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [x] I tested this change locally.
- [x] I added or updated tests, or tests are not reasonable for this change.
- [x] I added screenshots or recordings, or this change does not affect the UI.

Explicit permission feedback item (required if not a bug fix):

Not required; this is a bug fix.

## Related

- https://yaak.app/feedback/posts/while-entering-chinese-clicking-enter-to-confirm-the-changes-in-chinese-auto-sav
- The related feedback includes recordings of the broken Yaak behavior and the expected comparison behavior.

## Verification

- `npx vp test` — 32 test files and 267 tests passed
- `npx tsc --noEmit -p packages/ui/tsconfig.json`
- `npm run lint`
- Manually verified with WeType Pinyin on macOS in the local development build: the first Enter accepts the IME candidate without closing the rename input, and a later ordinary Enter saves the name.

## Attribution

Implemented and verified with OpenAI Codex.
