### PR TITLE
Fix nested template function depth tracking

### DIFF
--- a/crates/yaak-templates/src/renderer.rs
+++ b/crates/yaak-templates/src/renderer.rs
@@ -135,6 +135,10 @@ async fn render_value<T: TemplateCallback>(
     opt: &RenderOptions,
     depth: usize,
 ) -> Result<String> {
+    if depth > MAX_DEPTH {
+        return opt.error_behavior.handle(Err(RenderStackExceededError));
+    }
+
     let v = match val {
         Val::Str { text } => {
             let r = Box::pin(parse_and_render_at_depth(&text, vars, cb, opt, depth)).await?;
@@ -154,7 +158,7 @@ async fn render_value<T: TemplateCallback>(
                     Val::Bool { value } => serde_json::Value::Bool(value),
                     Val::Null => serde_json::Value::Null,
                     _ => serde_json::Value::String(
-                        Box::pin(render_value(a.value, vars, cb, opt, depth)).await?,
+                        Box::pin(render_value(a.value, vars, cb, opt, depth + 1)).await?,
                     ),
                 };
                 resolved_args.insert(a.name, v);
@@ -495,6 +499,50 @@ mod parse_and_render_tests {
             }
         }
         assert_eq!(parse_and_render(template, &vars, &CB {}, &opt).await?, result.to_string());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_nested_function_args_beyond_max_depth() -> Result<()> {
+        struct CB {}
+        impl TemplateCallback for CB {
+            async fn run(
+                &self,
+                _fn_name: &str,
+                args: HashMap<String, serde_json::Value>,
+            ) -> Result<String> {
+                Ok(args["value"].as_str().unwrap_or_default().to_string())
+            }
+
+            fn transform_arg(
+                &self,
+                _fn_name: &str,
+                _arg_name: &str,
+                arg_value: &str,
+            ) -> Result<String> {
+                Ok(arg_value.to_string())
+            }
+        }
+
+        let nested_beyond_limit = (0..=super::MAX_DEPTH)
+            .fold("'ok'".to_string(), |value, _| format!("identity(value={value})"));
+        let template_beyond_limit = format!("${{[ {nested_beyond_limit} ]}}");
+        let vars = HashMap::new();
+
+        assert_eq!(
+            parse_and_render(&template_beyond_limit, &vars, &CB {}, &RenderOptions::throw()).await,
+            Err(RenderStackExceededError)
+        );
+        assert_eq!(
+            parse_and_render(
+                &template_beyond_limit,
+                &vars,
+                &CB {},
+                &RenderOptions::return_empty(),
+            )
+            .await,
+            Ok(String::new())
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Count recursive template-function argument evaluation toward the existing render depth budget. This prevents deeply nested function arguments from bypassing `MAX_DEPTH`, while preserving normal nesting and the established `Throw` and `ReturnEmpty` behaviors.

## Root cause

The `Val::Fn` argument resolver recursively called `render_value` with the unchanged depth. Unlike variable and returned-template recursion, a chain such as `f(value=f(value=...))` could therefore descend without reaching the guard in `render`.

## Submission

- [x] This PR is a bug fix.
- [ ] If this PR is not a bug fix, I linked the feedback item where @gschier explicitly gave me permission to work on it.
- [x] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [x] I tested this change locally.
- [x] I added or updated tests, or tests are not reasonable for this change.
- [x] I added screenshots or recordings, or this change does not affect the UI.

Explicit permission feedback item (required if not a bug fix):

Not required; this is a bug fix.

## Related

- https://yaak.app/feedback/posts/three-unguarded-recursion-cache-paths-in-main-1b28dfd
- This PR addresses only the “Nested function args → MAX_DEPTH bypass” item.

## Verification

- `cargo test -p yaak-templates` — 92 unit tests and all doc tests passed
- `cargo check -p yaak-templates`
- `cargo fmt -p yaak-templates -- --check`
- `npm test`
- `npm run lint` — passed with two existing TypeScript warnings outside this change

## Attribution

Implemented and verified with OpenAI Codex.
