### PR TITLE
Correct timestamp.format help text to reference date-fns, not dayjs

### DIFF
--- a/plugins/template-function-timestamp/src/index.ts
+++ b/plugins/template-function-timestamp/src/index.ts
@@ -42,7 +42,9 @@ const expressionArg: TemplateFunctionArg = {
 const formatArg: TemplateFunctionArg = {
   name: "format",
   label: "Format String",
-  description: "Format string to describe the output (eg. 'yyyy-MM-dd at HH:mm:ss')",
+  description:
+    "date-fns format string to describe the output (eg. \"yyyy-MM-dd 'at' HH:mm:ss\"). " +
+    "Wrap literal text in single quotes to escape it",
   optional: true,
   placeholder: "yyyy-MM-dd HH:mm:ss",
   type: "text",
@@ -79,7 +81,7 @@ export const plugin: PluginDefinition = {
     },
     {
       name: "timestamp.format",
-      description: "Format a date using a dayjs-compatible format string",
+      description: "Format a date using a date-fns format string",
       args: [dateArg, formatArg],
       previewArgs: [formatArg.name],
       onRender: async (_ctx, args) => formatDatetime(args.values),


### PR DESCRIPTION
`timestamp.format` passes the format string to date-fns, but the description advertised dayjs. The two disagree on escaping (`'MM'` vs `[MM]`) and on tokens — `yyyy-MM-dd HH:mm:ss` renders as `yyyy-08-We` under dayjs, so switching libraries was not an option.

The example was also unescaped: `yyyy-MM-dd at HH:mm:ss` renders as `2026-08-12 AM1786548645 08:30:45`, since `a` and `t` are live tokens.

Reported in https://yaak.app/feedback/posts/timestamp-formatting-not-escaping