### PR TITLE
Link date-fns format docs from timestamp.format

### DIFF
--- a/plugins/template-function-timestamp/src/index.ts
+++ b/plugins/template-function-timestamp/src/index.ts
@@ -50,6 +50,19 @@ const formatArg: TemplateFunctionArg = {
   type: "text",
 };
 
+const formatDocsBanner: TemplateFunctionArg = {
+  type: "banner",
+  color: "info",
+  inputs: [
+    {
+      type: "markdown",
+      content:
+        "Uses [date-fns format tokens](https://date-fns.org/docs/format), " +
+        "not dayjs or Moment. Wrap literal text in single quotes to escape it.",
+    },
+  ],
+};
+
 export const plugin: PluginDefinition = {
   templateFunctions: [
     {
@@ -82,7 +95,7 @@ export const plugin: PluginDefinition = {
     {
       name: "timestamp.format",
       description: "Format a date using a date-fns format string",
-      args: [dateArg, formatArg],
+      args: [formatDocsBanner, dateArg, formatArg],
       previewArgs: [formatArg.name],
       onRender: async (_ctx, args) => formatDatetime(args.values),
     },


### PR DESCRIPTION
Follow-up to #527, which corrected the description but left users with no pointer to the actual token reference.

Adds an info banner to `timestamp.format` linking https://date-fns.org/docs/format, and states the escaping rule (single quotes, not square brackets) where it's visible while editing the format string — the Format String help tooltip renders plain text, so it can't carry a link.

Uses the existing `banner` + `markdown` arg pattern already used by `auth-ntlm`, `auth-oauth1`, and the `faker` plugin.

Reported in https://yaak.app/feedback/posts/timestamp-formatting-not-escaping