### PR TITLE
Honor workspace connection settings in CLI sends

### DIFF
--- a/crates-cli/yaak-cli/src/commands/request.rs
+++ b/crates-cli/yaak-cli/src/commands/request.rs
@@ -585,7 +585,7 @@ async fn send_http_request_by_id(
         encryption_manager: ctx.encryption_manager.clone(),
         plugin_context: &plugin_context,
         cancelled_rx: None,
-        connection_manager: None,
+        connection_manager: ctx.connection_manager(),
     })
     .await;
 

--- a/crates-cli/yaak-cli/src/context.rs
+++ b/crates-cli/yaak-cli/src/context.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use yaak_crypto::manager::EncryptionManager;
+use yaak_http::manager::HttpConnectionManager;
 use yaak_models::blob_manager::BlobManager;
 use yaak_models::client_db::ClientDb;
 use yaak_models::query_manager::QueryManager;
@@ -31,6 +32,7 @@ pub struct CliContext {
     query_manager: QueryManager,
     blob_manager: BlobManager,
     pub encryption_manager: Arc<EncryptionManager>,
+    connection_manager: Arc<HttpConnectionManager>,
     plugin_manager: Option<Arc<PluginManager>>,
     plugin_event_bridge: Mutex<Option<CliPluginEventBridge>>,
 }
@@ -54,6 +56,7 @@ impl CliContext {
             query_manager,
             blob_manager,
             encryption_manager,
+            connection_manager: Arc::new(HttpConnectionManager::new()),
             plugin_manager: None,
             plugin_event_bridge: Mutex::new(None),
         }
@@ -91,6 +94,7 @@ impl CliContext {
                     self.query_manager.clone(),
                     self.blob_manager.clone(),
                     self.encryption_manager.clone(),
+                    self.connection_manager.clone(),
                     self.data_dir.clone(),
                     execution_context,
                 )
@@ -118,6 +122,10 @@ impl CliContext {
 
     pub fn blob_manager(&self) -> &BlobManager {
         &self.blob_manager
+    }
+
+    pub fn connection_manager(&self) -> &HttpConnectionManager {
+        &self.connection_manager
     }
 
     pub fn plugin_manager(&self) -> Arc<PluginManager> {

--- a/crates-cli/yaak-cli/src/plugin_events.rs
+++ b/crates-cli/yaak-cli/src/plugin_events.rs
@@ -15,6 +15,7 @@ use yaak::render::{render_grpc_request, render_http_request};
 use yaak::send::{SendHttpRequestWithPluginsParams, send_http_request_with_plugins};
 use yaak_crypto::manager::EncryptionManager;
 use yaak_http::cookies::get_cookie_value_from_jar;
+use yaak_http::manager::HttpConnectionManager;
 use yaak_models::blob_manager::BlobManager;
 use yaak_models::models::Environment;
 use yaak_models::queries::any_request::AnyRequest;
@@ -42,6 +43,7 @@ struct CliHostContext {
     blob_manager: BlobManager,
     plugin_manager: Arc<PluginManager>,
     encryption_manager: Arc<EncryptionManager>,
+    connection_manager: Arc<HttpConnectionManager>,
     response_dir: PathBuf,
     execution_context: CliExecutionContext,
 }
@@ -52,6 +54,7 @@ impl CliPluginEventBridge {
         query_manager: QueryManager,
         blob_manager: BlobManager,
         encryption_manager: Arc<EncryptionManager>,
+        connection_manager: Arc<HttpConnectionManager>,
         data_dir: PathBuf,
         execution_context: CliExecutionContext,
     ) -> Self {
@@ -63,6 +66,7 @@ impl CliPluginEventBridge {
             blob_manager,
             plugin_manager,
             encryption_manager,
+            connection_manager,
             response_dir: data_dir.join("responses"),
             execution_context,
         });
@@ -214,7 +218,7 @@ async fn build_plugin_reply(
                     encryption_manager: host_context.encryption_manager.clone(),
                     plugin_context: &plugin_context,
                     cancelled_rx: None,
-                    connection_manager: None,
+                    connection_manager: &host_context.connection_manager,
                 })
                 .await
                 {

--- a/crates-tauri/yaak-app-client/src/http_request.rs
+++ b/crates-tauri/yaak-app-client/src/http_request.rs
@@ -160,7 +160,7 @@ async fn send_http_request_inner<R: Runtime>(
         encryption_manager,
         plugin_context,
         cancelled_rx: Some(cancelled_rx.clone()),
-        connection_manager: Some(connection_manager.inner()),
+        connection_manager: connection_manager.inner(),
     })
     .await
     .map_err(|e| GenericError(e.to_string()))?;

--- a/crates/yaak/src/send.rs
+++ b/crates/yaak/src/send.rs
@@ -127,31 +127,6 @@ pub struct CookieBehavior {
     pub store_cookies: bool,
 }
 
-struct DefaultSendRequestExecutor;
-
-#[async_trait]
-impl SendRequestExecutor for DefaultSendRequestExecutor {
-    async fn send(
-        &self,
-        sendable_request: SendableHttpRequest,
-        event_tx: mpsc::Sender<SenderHttpResponseEvent>,
-        cookie_behavior: CookieBehavior,
-    ) -> yaak_http::error::Result<yaak_http::sender::HttpResponse> {
-        let sender = ReqwestSender::new()?;
-        let transaction = match cookie_behavior.store {
-            Some(store) => HttpTransaction::with_cookie_behavior(
-                sender,
-                store,
-                cookie_behavior.send_cookies,
-                cookie_behavior.store_cookies,
-            ),
-            None => HttpTransaction::new(sender),
-        };
-        let (_cancel_tx, cancel_rx) = watch::channel(false);
-        transaction.execute_with_cancellation(sendable_request, cancel_rx, event_tx).await
-    }
-}
-
 struct PluginPrepareSendableRequest {
     plugin_manager: Arc<PluginManager>,
     plugin_context: PluginContext,
@@ -259,7 +234,7 @@ pub struct SendHttpRequestByIdParams<'a, T: TemplateCallback> {
     pub emit_response_body_chunks_to: Option<mpsc::UnboundedSender<Vec<u8>>>,
     pub cancelled_rx: Option<watch::Receiver<bool>>,
     pub prepare_sendable_request: Option<&'a dyn PrepareSendableRequest>,
-    pub executor: Option<&'a dyn SendRequestExecutor>,
+    pub executor: &'a dyn SendRequestExecutor,
 }
 
 pub struct SendHttpRequestParams<'a, T: TemplateCallback> {
@@ -278,7 +253,7 @@ pub struct SendHttpRequestParams<'a, T: TemplateCallback> {
     pub auth_context_id: Option<String>,
     pub existing_response: Option<HttpResponse>,
     pub prepare_sendable_request: Option<&'a dyn PrepareSendableRequest>,
-    pub executor: Option<&'a dyn SendRequestExecutor>,
+    pub executor: &'a dyn SendRequestExecutor,
 }
 
 pub struct SendHttpRequestWithPluginsParams<'a> {
@@ -296,7 +271,7 @@ pub struct SendHttpRequestWithPluginsParams<'a> {
     pub encryption_manager: Arc<EncryptionManager>,
     pub plugin_context: &'a PluginContext,
     pub cancelled_rx: Option<watch::Receiver<bool>>,
-    pub connection_manager: Option<&'a HttpConnectionManager>,
+    pub connection_manager: &'a HttpConnectionManager,
 }
 
 pub struct SendHttpRequestByIdWithPluginsParams<'a> {
@@ -313,7 +288,7 @@ pub struct SendHttpRequestByIdWithPluginsParams<'a> {
     pub encryption_manager: Arc<EncryptionManager>,
     pub plugin_context: &'a PluginContext,
     pub cancelled_rx: Option<watch::Receiver<bool>>,
-    pub connection_manager: Option<&'a HttpConnectionManager>,
+    pub connection_manager: &'a HttpConnectionManager,
 }
 
 pub struct SendHttpRequestResult {
@@ -403,14 +378,13 @@ pub async fn send_http_request_with_plugins(
         plugin_context: params.plugin_context.clone(),
         cancelled_rx: params.cancelled_rx.clone(),
     };
-    let executor =
-        params.connection_manager.map(|connection_manager| ConnectionManagerSendRequestExecutor {
-            connection_manager,
-            plugin_context_id: params.plugin_context.id.clone(),
-            query_manager: params.query_manager.clone(),
-            request: params.request.clone(),
-            cancelled_rx: params.cancelled_rx.clone(),
-        });
+    let executor = ConnectionManagerSendRequestExecutor {
+        connection_manager: params.connection_manager,
+        plugin_context_id: params.plugin_context.id.clone(),
+        query_manager: params.query_manager.clone(),
+        request: params.request.clone(),
+        cancelled_rx: params.cancelled_rx.clone(),
+    };
 
     send_http_request(SendHttpRequestParams {
         query_manager: params.query_manager,
@@ -428,7 +402,7 @@ pub async fn send_http_request_with_plugins(
         auth_context_id: None,
         existing_response: params.existing_response,
         prepare_sendable_request: Some(&auth_hook),
-        executor: executor.as_ref().map(|e| e as &dyn SendRequestExecutor),
+        executor: &executor,
     })
     .await
 }
@@ -613,8 +587,7 @@ pub async fn send_http_request<T: TemplateCallback>(
         }
     });
 
-    let default_executor = DefaultSendRequestExecutor;
-    let executor = params.executor.unwrap_or(&default_executor);
+    let executor = params.executor;
     let started_at = Instant::now();
     let request_started_url = sendable_request.url.clone();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "@tauri-apps/cli": "npm:@tauri-apps/cli-cef@3.0.0-alpha.6",
         "@types/babel__core": "^7.20.5",
         "@vitejs/plugin-react": "^6.0.1",
-        "@yaakapp/cli": "*",
+        "@yaakapp/cli": "latest",
         "babel-plugin-react-compiler": "^1.0.0",
         "dotenv-cli": "^11.0.0",
         "nodejs-file-downloader": "^4.13.0",


### PR DESCRIPTION
CLI sends passed `connection_manager: None` and fell back to a default reqwest client, silently ignoring workspace connection settings (proxy, client certificates, `validate_certificates`, DNS overrides).

- `CliContext` now owns an `HttpConnectionManager`, wired into the `send` command and the plugin bridge's `SendHttpRequest` handler
- `connection_manager` and `executor` are now required on the shared send path, and the silent `DefaultSendRequestExecutor` fallback is removed, so this can't regress

Verified against a self-signed HTTPS server: `settingValidateCertificates: false` now succeeds from the CLI, and flipping it back to `true` fails with a certificate error.