### PR TITLE
Fix sync watcher panic when the sync directory path traverses a symlink

### DIFF
--- a/crates/yaak-sync/src/watch.rs
+++ b/crates/yaak-sync/src/watch.rs
@@ -27,7 +27,10 @@ pub async fn watch_directory<F>(
 where
     F: Fn(WatchEvent) + Send + 'static,
 {
-    let dir = dir.to_owned();
+    // Canonicalize so reported event paths match the watched root. Notify reports
+    // resolved paths, so watching through a symlink (e.g. /tmp -> /private/tmp on
+    // macOS) would otherwise make every strip_prefix below fail.
+    let dir = dir.canonicalize().unwrap_or_else(|_| dir.to_owned());
     let (tx, rx) = mpsc::channel::<notify::Result<notify::Event>>();
     let mut watcher = notify::recommended_watcher(tx)?;
 
@@ -41,9 +44,12 @@ where
         }
     });
 
+    watcher.watch(&dir, notify::RecursiveMode::Recursive)?;
+    info!("Watching directory {:?}", dir);
+
     tokio::spawn(async move {
-        watcher.watch(&dir, notify::RecursiveMode::Recursive).expect("Failed to watch directory");
-        info!("Watching directory {:?}", dir);
+        // Keep the watcher alive for the lifetime of the task
+        let _watcher = watcher;
 
         loop {
             select! {
@@ -53,7 +59,7 @@ where
                         Ok(event) => {
                             // Filter out any ignored directories and see if we still get a result
                             let paths = event.paths.into_iter()
-                                .map(|p| p.strip_prefix(&dir).unwrap().to_path_buf())
+                                .map(|p| p.strip_prefix(&dir).unwrap_or(&p).to_path_buf())
                                 .filter(|p| !p.starts_with(".git") && !p.starts_with("node_modules"))
                                 .collect::<Vec<PathBuf>>();
 


### PR DESCRIPTION
notify reports events with resolved paths, so watching a directory reached through a symlink (e.g. `/tmp` -> `/private/tmp` on macOS) made `strip_prefix` fail and the `unwrap` panic the spawned watcher task — sync file events silently stopped.

- Canonicalize the directory before watching so event paths match the root
- Fall back to the raw path instead of unwrapping if `strip_prefix` still fails
- Register the watch before spawning so setup failures (missing dir, permissions) return an error to the caller instead of panicking inside the task