### PR TITLE
Read OAuth 2.0 token responses through the plugin body API

### DIFF
--- a/plugins/auth-oauth2/src/fetchAccessToken.ts
+++ b/plugins/auth-oauth2/src/fetchAccessToken.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from "node:fs";
 import type { Context, HttpRequest, HttpUrlParameter } from "@yaakapp/api";
 import type { AccessTokenRawResponse } from "./store";
 
@@ -57,7 +56,7 @@ export async function fetchAccessToken(
   }
 
   httpRequest.authenticationType = "none"; // Don't inherit workspace auth
-  const { httpResponse: resp } = await ctx.httpRequest.send({ httpRequest });
+  const { httpResponse: resp, body: responseBody } = await ctx.httpRequest.send({ httpRequest });
 
   console.log("[oauth2] Got access token response", resp.status);
 
@@ -65,7 +64,8 @@ export async function fetchAccessToken(
     throw new Error(`Failed to fetch access token: ${resp.error}`);
   }
 
-  const body = resp.bodyPath ? readFileSync(resp.bodyPath, "utf8") : "";
+  // Empty when the response had no body, which parses to {} below.
+  const body = await responseBody.text();
 
   if (resp.status < 200 || resp.status >= 300) {
     throw new Error(`Failed to fetch access token with status=${resp.status} and body=${body}`);

--- a/plugins/auth-oauth2/src/getOrRefreshAccessToken.ts
+++ b/plugins/auth-oauth2/src/getOrRefreshAccessToken.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from "node:fs";
 import type { Context, HttpRequest } from "@yaakapp/api";
 import type { AccessToken, AccessTokenRawResponse, TokenStoreArgs } from "./store";
 import { deleteToken, getToken, storeToken } from "./store";
@@ -71,7 +70,7 @@ export async function getOrRefreshAccessToken(
   }
 
   httpRequest.authenticationType = "none"; // Don't inherit workspace auth
-  const { httpResponse: resp } = await ctx.httpRequest.send({ httpRequest });
+  const { httpResponse: resp, body: responseBody } = await ctx.httpRequest.send({ httpRequest });
 
   if (resp.error) {
     throw new Error(`Failed to refresh access token: ${resp.error}`);
@@ -85,7 +84,8 @@ export async function getOrRefreshAccessToken(
     return null;
   }
 
-  const body = resp.bodyPath ? readFileSync(resp.bodyPath, "utf8") : "";
+  // Empty when the response had no body, which parses to {} below.
+  const body = await responseBody.text();
 
   console.log("[oauth2] Got refresh token response", resp.status);
 


### PR DESCRIPTION
Ports `auth-oauth2` off `readFileSync(resp.bodyPath)`, so the plugin keeps working once bodies move into the blob DB and in the browser Worker, where there is no fs.

Both call sites take the body from the send, which #560 now hands back alongside the response. No id, no lookup, no helper.

`text()` on a response with no body returns `""`, which is what `resp.bodyPath ? ... : ""` produced, so an empty response still parses to `{}` instead of throwing.

Based on #560 for `send()` returning `SentHttpRequest`.

Checks: tsc, lint, and the plugin's 24 tests pass. The OAuth flows themselves are unverified; authorization code and client credentials against a live provider is still the outstanding check.