### PR TITLE
Move plugin actions and authentication onto PluginHost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11352,7 +11352,6 @@ dependencies = [
 name = "yaak-commands"
 version = "0.0.0"
 dependencies = [
- "log 0.4.29",
  "serde_json",
  "tempfile",
  "thiserror 2.0.17",

--- a/crates-tauri/yaak-app-client/src/grpc.rs
+++ b/crates-tauri/yaak-app-client/src/grpc.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 
 use crate::PluginContextExt;
 use crate::error::Result;
-use crate::models_ext::QueryManagerExt;
 use KeyAndValueRef::{Ascii, Binary};
 use tauri::{Manager, Runtime, WebviewWindow};
 use yaak_grpc::{KeyAndValueRef, MetadataMap};
@@ -21,22 +20,6 @@ pub(crate) fn metadata_to_map(metadata: MetadataMap) -> BTreeMap<String, String>
     entries
 }
 
-pub(crate) fn resolve_grpc_request<R: Runtime>(
-    window: &WebviewWindow<R>,
-    request: &GrpcRequest,
-) -> Result<(GrpcRequest, String)> {
-    let mut new_request = request.clone();
-
-    let (authentication_type, authentication, authentication_context_id) =
-        window.db().resolve_auth_for_grpc_request(request)?;
-    new_request.authentication_type = authentication_type;
-    new_request.authentication = authentication;
-
-    let metadata = window.db().resolve_metadata_for_grpc_request(request)?;
-    new_request.metadata = metadata;
-
-    Ok((new_request, authentication_context_id))
-}
 
 pub(crate) async fn build_metadata<R: Runtime>(
     window: &WebviewWindow<R>,

--- a/crates-tauri/yaak-app-client/src/http_request.rs
+++ b/crates-tauri/yaak-app-client/src/http_request.rs
@@ -179,19 +179,3 @@ async fn send_http_request_inner<R: Runtime>(
     Ok(SentHttpRequest { response: result.response, body: result.response_body })
 }
 
-pub fn resolve_http_request<R: Runtime>(
-    window: &WebviewWindow<R>,
-    request: &HttpRequest,
-) -> Result<(HttpRequest, String)> {
-    let mut new_request = request.clone();
-
-    let (authentication_type, authentication, authentication_context_id) =
-        window.db().resolve_auth_for_http_request(request)?;
-    new_request.authentication_type = authentication_type;
-    new_request.authentication = authentication;
-
-    let headers = window.db().resolve_headers_for_http_request(request)?;
-    new_request.headers = headers;
-
-    Ok((new_request, authentication_context_id))
-}

--- a/crates-tauri/yaak-app-client/src/lib.rs
+++ b/crates-tauri/yaak-app-client/src/lib.rs
@@ -2,18 +2,17 @@ extern crate core;
 use crate::encoding::read_response_body;
 use crate::error::Error::GenericError;
 use crate::error::Result;
-use crate::grpc::{build_metadata, metadata_to_map, resolve_grpc_request};
-use crate::http_request::{resolve_http_request, send_http_request};
+use crate::grpc::{build_metadata, metadata_to_map};
+use crate::http_request::send_http_request;
 use crate::import::{import_data, import_url};
 use crate::models_ext::{BlobManagerExt, QueryManagerExt};
 use crate::notifications::YaakNotifier;
-use crate::render::{render_grpc_request, render_json_value, render_template};
+use crate::render::{render_grpc_request, render_template};
 use crate::updates::{UpdateMode, UpdateTrigger, YaakUpdater};
 use crate::uri_scheme::handle_deep_link;
 use error::Result as YaakResult;
 use eventsource_client::{EventParser, SSE};
 use log::{debug, error, info, warn};
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -31,25 +30,20 @@ use tokio::task::block_in_place;
 use tokio::time;
 use yaak::send::ResponseBody;
 use yaak_commands::responses::locate_response_body;
+use yaak_commands::resolve::resolve_grpc_request;
 use yaak_common::command::new_checked_command;
 use yaak_crypto::manager::EncryptionManager;
 use yaak_grpc::manager::{GrpcConfig, GrpcHandle};
 use yaak_grpc::{Code, ServiceDefinition};
 use yaak_mac_window::AppHandleMacWindowExt;
 use yaak_models::models::{
-    AnyModel, CookieJar, Environment, GrpcConnection, GrpcConnectionState, GrpcEvent,
+    CookieJar, Environment, GrpcConnection, GrpcConnectionState, GrpcEvent,
     GrpcEventType, HttpRequest, HttpResponse, HttpResponseState, Workspace,
 };
 use yaak_models::util::{BatchUpsertResult, UpdateSource};
 use yaak_plugins::events::{
-    CallFolderActionArgs, CallFolderActionRequest, CallGrpcRequestActionArgs,
-    CallGrpcRequestActionRequest, CallHttpRequestActionArgs, CallHttpRequestActionRequest,
-    CallWebsocketRequestActionArgs, CallWebsocketRequestActionRequest, CallWorkspaceActionArgs,
-    CallWorkspaceActionRequest, Color, ErrorResponse, FilterResponse, GetFolderActionsResponse,
-    GetGrpcRequestActionsResponse, GetHttpAuthenticationConfigResponse,
-    GetHttpAuthenticationSummaryResponse, GetHttpRequestActionsResponse,
-    GetWebsocketRequestActionsResponse, GetWorkspaceActionsResponse, InternalEvent,
-    InternalEventPayload, JsonPrimitive, PluginContext, RenderPurpose, ShowToastRequest,
+    Color, ErrorResponse, FilterResponse, InternalEvent, InternalEventPayload, PluginContext,
+    RenderPurpose, ShowToastRequest,
 };
 use yaak_plugins::manager::PluginManager;
 use yaak_plugins::template_callback::PluginTemplateCallback;
@@ -244,7 +238,8 @@ async fn cmd_grpc_reflect<R: Runtime>(
     grpc_handle: State<'_, Mutex<GrpcHandle>>,
 ) -> YaakResult<Vec<ServiceDefinition>> {
     let unrendered_request = app_handle.db().get_grpc_request(request_id)?;
-    let (resolved_request, auth_context_id) = resolve_grpc_request(&window, &unrendered_request)?;
+    let (resolved_request, auth_context_id) =
+        resolve_grpc_request(&window.db(), &unrendered_request)?;
 
     let environment_chain = app_handle.db().resolve_environments(
         &unrendered_request.workspace_id,
@@ -304,7 +299,8 @@ async fn cmd_grpc_go<R: Runtime>(
     grpc_handle: State<'_, Mutex<GrpcHandle>>,
 ) -> YaakResult<String> {
     let unrendered_request = app_handle.db().get_grpc_request(request_id)?;
-    let (resolved_request, auth_context_id) = resolve_grpc_request(&window, &unrendered_request)?;
+    let (resolved_request, auth_context_id) =
+        resolve_grpc_request(&window.db(), &unrendered_request)?;
     let environment_chain = app_handle.db().resolve_environments(
         &unrendered_request.workspace_id,
         unrendered_request.folder_id.as_deref(),
@@ -1028,262 +1024,19 @@ async fn cmd_import_url<R: Runtime>(
     import_url(&window, url).await
 }
 
-async fn cmd_http_request_actions<R: Runtime>(
-    window: WebviewWindow<R>,
-    plugin_manager: State<'_, PluginManager>,
-) -> YaakResult<Vec<GetHttpRequestActionsResponse>> {
-    Ok(plugin_manager.get_http_request_actions(&window.plugin_context()).await?)
-}
 
-async fn cmd_websocket_request_actions<R: Runtime>(
-    window: WebviewWindow<R>,
-    plugin_manager: State<'_, PluginManager>,
-) -> YaakResult<Vec<GetWebsocketRequestActionsResponse>> {
-    Ok(plugin_manager.get_websocket_request_actions(&window.plugin_context()).await?)
-}
 
-async fn cmd_call_websocket_request_action<R: Runtime>(
-    window: WebviewWindow<R>,
-    req: CallWebsocketRequestActionRequest,
-    plugin_manager: State<'_, PluginManager>,
-) -> YaakResult<()> {
-    let websocket_request = window.db().get_websocket_request(&req.args.websocket_request.id)?;
-    Ok(plugin_manager
-        .call_websocket_request_action(
-            &window.plugin_context(),
-            CallWebsocketRequestActionRequest {
-                args: CallWebsocketRequestActionArgs { websocket_request },
-                ..req
-            },
-        )
-        .await?)
-}
 
-async fn cmd_workspace_actions<R: Runtime>(
-    window: WebviewWindow<R>,
-    plugin_manager: State<'_, PluginManager>,
-) -> YaakResult<Vec<GetWorkspaceActionsResponse>> {
-    Ok(plugin_manager.get_workspace_actions(&window.plugin_context()).await?)
-}
 
-async fn cmd_call_workspace_action<R: Runtime>(
-    window: WebviewWindow<R>,
-    req: CallWorkspaceActionRequest,
-    plugin_manager: State<'_, PluginManager>,
-) -> YaakResult<()> {
-    let workspace = window.db().get_workspace(&req.args.workspace.id)?;
-    Ok(plugin_manager
-        .call_workspace_action(
-            &window.plugin_context(),
-            CallWorkspaceActionRequest { args: CallWorkspaceActionArgs { workspace }, ..req },
-        )
-        .await?)
-}
 
-async fn cmd_folder_actions<R: Runtime>(
-    window: WebviewWindow<R>,
-    plugin_manager: State<'_, PluginManager>,
-) -> YaakResult<Vec<GetFolderActionsResponse>> {
-    Ok(plugin_manager.get_folder_actions(&window.plugin_context()).await?)
-}
 
-async fn cmd_call_folder_action<R: Runtime>(
-    window: WebviewWindow<R>,
-    req: CallFolderActionRequest,
-    plugin_manager: State<'_, PluginManager>,
-) -> YaakResult<()> {
-    let folder = window.db().get_folder(&req.args.folder.id)?;
-    Ok(plugin_manager
-        .call_folder_action(
-            &window.plugin_context(),
-            CallFolderActionRequest { args: CallFolderActionArgs { folder }, ..req },
-        )
-        .await?)
-}
 
-async fn cmd_grpc_request_actions<R: Runtime>(
-    window: WebviewWindow<R>,
-    plugin_manager: State<'_, PluginManager>,
-) -> YaakResult<Vec<GetGrpcRequestActionsResponse>> {
-    Ok(plugin_manager.get_grpc_request_actions(&window.plugin_context()).await?)
-}
 
-async fn cmd_get_http_authentication_summaries<R: Runtime>(
-    window: WebviewWindow<R>,
-    plugin_manager: State<'_, PluginManager>,
-) -> YaakResult<Vec<GetHttpAuthenticationSummaryResponse>> {
-    let results =
-        plugin_manager.get_http_authentication_summaries(&window.plugin_context()).await?;
-    Ok(results.into_iter().map(|(_, a)| a).collect())
-}
 
-async fn cmd_get_http_authentication_config<R: Runtime>(
-    window: WebviewWindow<R>,
-    app_handle: AppHandle<R>,
-    plugin_manager: State<'_, PluginManager>,
-    encryption_manager: State<'_, EncryptionManager>,
-    auth_name: &str,
-    values: HashMap<String, JsonPrimitive>,
-    model: AnyModel,
-    environment_id: Option<&str>,
-) -> YaakResult<GetHttpAuthenticationConfigResponse> {
-    // Extract workspace_id and folder_id from the model to resolve the environment chain
-    let (workspace_id, folder_id) = match &model {
-        AnyModel::HttpRequest(r) => (r.workspace_id.clone(), r.folder_id.clone()),
-        AnyModel::GrpcRequest(r) => (r.workspace_id.clone(), r.folder_id.clone()),
-        AnyModel::WebsocketRequest(r) => (r.workspace_id.clone(), r.folder_id.clone()),
-        AnyModel::Folder(f) => (f.workspace_id.clone(), f.folder_id.clone()),
-        AnyModel::Workspace(w) => (w.id.clone(), None),
-        _ => return Err(GenericError("Unsupported model type for authentication config".into())),
-    };
 
-    // Resolve environment chain and render the values for token lookup
-    let environment_chain = app_handle.db().resolve_environments(
-        &workspace_id,
-        folder_id.as_deref(),
-        environment_id,
-    )?;
-    let plugin_manager_arc = Arc::new((*plugin_manager).clone());
-    let encryption_manager_arc = Arc::new((*encryption_manager).clone());
-    let cb = PluginTemplateCallback::new(
-        plugin_manager_arc,
-        encryption_manager_arc,
-        &window.plugin_context(),
-        RenderPurpose::Preview,
-    );
 
-    // Convert HashMap<String, JsonPrimitive> to serde_json::Value for rendering
-    let values_json: serde_json::Value = serde_json::to_value(&values)?;
-    let rendered_json =
-        render_json_value(values_json, environment_chain, &cb, &RenderOptions::return_empty())
-            .await?;
 
-    // Convert back to HashMap<String, JsonPrimitive>
-    let rendered_values: HashMap<String, JsonPrimitive> = serde_json::from_value(rendered_json)?;
 
-    Ok(plugin_manager
-        .get_http_authentication_config(
-            &window.plugin_context(),
-            auth_name,
-            rendered_values,
-            model.id(),
-        )
-        .await?)
-}
-
-async fn cmd_call_http_request_action<R: Runtime>(
-    window: WebviewWindow<R>,
-    req: CallHttpRequestActionRequest,
-    plugin_manager: State<'_, PluginManager>,
-) -> YaakResult<()> {
-    Ok(plugin_manager
-        .call_http_request_action(
-            &window.plugin_context(),
-            CallHttpRequestActionRequest {
-                args: CallHttpRequestActionArgs {
-                    http_request: resolve_http_request(&window, &req.args.http_request)?.0,
-                    ..req.args
-                },
-                ..req
-            },
-        )
-        .await?)
-}
-
-async fn cmd_call_grpc_request_action<R: Runtime>(
-    window: WebviewWindow<R>,
-    req: CallGrpcRequestActionRequest,
-    plugin_manager: State<'_, PluginManager>,
-) -> YaakResult<()> {
-    Ok(plugin_manager
-        .call_grpc_request_action(
-            &window.plugin_context(),
-            CallGrpcRequestActionRequest {
-                args: CallGrpcRequestActionArgs {
-                    grpc_request: resolve_grpc_request(&window, &req.args.grpc_request)?.0,
-                    ..req.args
-                },
-                ..req
-            },
-        )
-        .await?)
-}
-
-async fn cmd_call_http_authentication_action<R: Runtime>(
-    window: WebviewWindow<R>,
-    app_handle: AppHandle<R>,
-    plugin_manager: State<'_, PluginManager>,
-    encryption_manager: State<'_, EncryptionManager>,
-    auth_name: &str,
-    action_index: i32,
-    values: HashMap<String, JsonPrimitive>,
-    model: AnyModel,
-    environment_id: Option<&str>,
-) -> YaakResult<()> {
-    // Extract workspace_id and folder_id from the model to resolve the environment chain
-    let (workspace_id, folder_id) = match &model {
-        AnyModel::HttpRequest(r) => (r.workspace_id.clone(), r.folder_id.clone()),
-        AnyModel::GrpcRequest(r) => (r.workspace_id.clone(), r.folder_id.clone()),
-        AnyModel::WebsocketRequest(r) => (r.workspace_id.clone(), r.folder_id.clone()),
-        AnyModel::Folder(f) => (f.workspace_id.clone(), f.folder_id.clone()),
-        AnyModel::Workspace(w) => (w.id.clone(), None),
-        _ => return Err(GenericError("Unsupported model type for authentication action".into())),
-    };
-
-    // Resolve environment chain and render the values
-    let environment_chain = app_handle.db().resolve_environments(
-        &workspace_id,
-        folder_id.as_deref(),
-        environment_id,
-    )?;
-    let plugin_manager_arc = Arc::new((*plugin_manager).clone());
-    let encryption_manager_arc = Arc::new((*encryption_manager).clone());
-    let cb = PluginTemplateCallback::new(
-        plugin_manager_arc,
-        encryption_manager_arc,
-        &window.plugin_context(),
-        RenderPurpose::Send,
-    );
-
-    // Convert HashMap<String, JsonPrimitive> to serde_json::Value for rendering
-    let values_json: serde_json::Value = serde_json::to_value(&values)?;
-    let rendered_json =
-        render_json_value(values_json, environment_chain, &cb, &RenderOptions::throw()).await?;
-
-    // Convert back to HashMap<String, JsonPrimitive>
-    let rendered_values: HashMap<String, JsonPrimitive> = serde_json::from_value(rendered_json)?;
-
-    Ok(plugin_manager
-        .call_http_authentication_action(
-            &window.plugin_context(),
-            auth_name,
-            action_index,
-            rendered_values,
-            &model.id(),
-        )
-        .await?)
-}
-
-async fn cmd_curl_to_request<R: Runtime>(
-    window: WebviewWindow<R>,
-    command: &str,
-    plugin_manager: State<'_, PluginManager>,
-    workspace_id: &str,
-) -> YaakResult<HttpRequest> {
-    let import_result = plugin_manager.import_data(&window.plugin_context(), command).await?;
-
-    Ok(import_result
-        .resources
-        .http_requests
-        .get(0)
-        .ok_or(GenericError("No curl command found".to_string()))
-        .map(|r| {
-            let mut request = r.clone();
-            request.workspace_id = workspace_id.into();
-            request.id = "".to_string();
-            request
-        })?)
-}
 
 /// Decodes base64 and writes the bytes to a file the user picked.
 ///
@@ -1379,17 +1132,6 @@ async fn cmd_send_http_request<R: Runtime>(
     Ok(r)
 }
 
-async fn cmd_reload_plugins<R: Runtime>(
-    app_handle: AppHandle<R>,
-    window: WebviewWindow<R>,
-    plugin_manager: State<'_, PluginManager>,
-) -> YaakResult<Vec<(String, String)>> {
-    let plugins = app_handle.db().list_plugins()?;
-    let plugin_context =
-        PluginContext::new(Some(window.label().to_string()), window.workspace_id());
-    let errors = plugin_manager.initialize_all_plugins(plugins, &plugin_context).await;
-    Ok(errors)
-}
 
 async fn cmd_new_child_window<R: Runtime>(
     parent_window: WebviewWindow<R>,

--- a/crates-tauri/yaak-app-client/src/rpc_ext.rs
+++ b/crates-tauri/yaak-app-client/src/rpc_ext.rs
@@ -42,7 +42,9 @@ use yaak_models::models::{
 use yaak_models::query_manager::QueryManager;
 use yaak_models::util::BatchUpsertResult;
 use yaak_plugins::events::{
-    FilterResponse, JsonPrimitive, RenderPurpose, GetFolderActionsResponse, GetGrpcRequestActionsResponse,
+    CallFolderActionRequest, CallGrpcRequestActionRequest, CallHttpRequestActionRequest,
+    CallWebsocketRequestActionRequest, CallWorkspaceActionRequest, FilterResponse, ImportResponse,
+    JsonPrimitive, RenderPurpose, GetFolderActionsResponse, GetGrpcRequestActionsResponse,
     GetHttpAuthenticationConfigResponse, GetHttpAuthenticationSummaryResponse,
     GetHttpRequestActionsResponse, GetTemplateFunctionConfigResponse,
     GetTemplateFunctionSummaryResponse, GetThemesResponse, GetWebsocketRequestActionsResponse,
@@ -106,28 +108,35 @@ impl<R: Runtime> Host for ClientCtx<R> {
     }
 }
 
+impl<R: Runtime> ClientCtx<R> {
+    /// The plugin runtime this window talks to. Only the `PluginHost` impl
+    /// below uses it; everything else goes through the trait.
+    fn pm(&self) -> State<'_, PluginManager> {
+        self.window.state::<PluginManager>()
+    }
+}
+
 /// The desktop answers all of these out of the `PluginManager` it already
 /// runs — the Node sidecar. Each is a delegation, which is the point: the
 /// operations are what the handlers need, and this is one host's way of
 /// providing them.
 impl<R: Runtime> PluginHost for ClientCtx<R> {
     async fn loaded_plugin_metadata(&self, directory: &str) -> Option<PluginMetadata> {
-        let manager = self.window.state::<PluginManager>();
-        let handle = manager.get_plugin_by_dir(directory).await?;
+        let handle = self.pm().get_plugin_by_dir(directory).await?;
         Some(handle.info())
     }
 
     async fn take_plugin_init_errors(&self) -> Vec<(String, String)> {
-        self.window.state::<PluginManager>().take_init_errors().await
+        self.pm().take_init_errors().await
     }
 
     async fn resolve_plugins(&self, plugins: Vec<Plugin>) -> Vec<Plugin> {
-        self.window.state::<PluginManager>().resolve_plugins_for_runtime_from_db(plugins).await
+        self.pm().resolve_plugins_for_runtime_from_db(plugins).await
     }
 
     fn template_callback(&self, purpose: RenderPurpose) -> impl TemplateCallback {
         PluginTemplateCallback::new(
-            Arc::new((*self.window.state::<PluginManager>()).clone()),
+            Arc::new((*self.pm()).clone()),
             Arc::new(self.encryption_manager().clone()),
             &self.plugin_context(),
             purpose,
@@ -158,11 +167,118 @@ impl<R: Runtime> PluginHost for ClientCtx<R> {
     }
 
     async fn themes(&self) -> yaak_commands::Result<Vec<GetThemesResponse>> {
-        Ok(self.window.state::<PluginManager>().get_themes(&self.plugin_context()).await?)
+        Ok(self.pm().get_themes(&self.plugin_context()).await?)
+    }
+
+    async fn http_request_actions(
+        &self,
+    ) -> yaak_commands::Result<Vec<GetHttpRequestActionsResponse>> {
+        Ok(self.pm().get_http_request_actions(&self.plugin_context()).await?)
+    }
+
+    async fn websocket_request_actions(
+        &self,
+    ) -> yaak_commands::Result<Vec<GetWebsocketRequestActionsResponse>> {
+        Ok(self.pm().get_websocket_request_actions(&self.plugin_context()).await?)
+    }
+
+    async fn grpc_request_actions(
+        &self,
+    ) -> yaak_commands::Result<Vec<GetGrpcRequestActionsResponse>> {
+        Ok(self.pm().get_grpc_request_actions(&self.plugin_context()).await?)
+    }
+
+    async fn workspace_actions(&self) -> yaak_commands::Result<Vec<GetWorkspaceActionsResponse>> {
+        Ok(self.pm().get_workspace_actions(&self.plugin_context()).await?)
+    }
+
+    async fn folder_actions(&self) -> yaak_commands::Result<Vec<GetFolderActionsResponse>> {
+        Ok(self.pm().get_folder_actions(&self.plugin_context()).await?)
+    }
+
+    async fn call_http_request_action(
+        &self,
+        req: CallHttpRequestActionRequest,
+    ) -> yaak_commands::Result<()> {
+        Ok(self.pm().call_http_request_action(&self.plugin_context(), req).await?)
+    }
+
+    async fn call_grpc_request_action(
+        &self,
+        req: CallGrpcRequestActionRequest,
+    ) -> yaak_commands::Result<()> {
+        Ok(self.pm().call_grpc_request_action(&self.plugin_context(), req).await?)
+    }
+
+    async fn call_websocket_request_action(
+        &self,
+        req: CallWebsocketRequestActionRequest,
+    ) -> yaak_commands::Result<()> {
+        Ok(self.pm().call_websocket_request_action(&self.plugin_context(), req).await?)
+    }
+
+    async fn call_workspace_action(
+        &self,
+        req: CallWorkspaceActionRequest,
+    ) -> yaak_commands::Result<()> {
+        Ok(self.pm().call_workspace_action(&self.plugin_context(), req).await?)
+    }
+
+    async fn call_folder_action(
+        &self,
+        req: CallFolderActionRequest,
+    ) -> yaak_commands::Result<()> {
+        Ok(self.pm().call_folder_action(&self.plugin_context(), req).await?)
+    }
+
+    async fn http_authentication_summaries(
+        &self,
+    ) -> yaak_commands::Result<Vec<GetHttpAuthenticationSummaryResponse>> {
+        let results = self.pm().get_http_authentication_summaries(&self.plugin_context()).await?;
+        Ok(results.into_iter().map(|(_, a)| a).collect())
+    }
+
+    async fn http_authentication_config(
+        &self,
+        auth_name: &str,
+        values: HashMap<String, JsonPrimitive>,
+        model_id: &str,
+    ) -> yaak_commands::Result<GetHttpAuthenticationConfigResponse> {
+        Ok(self
+            .pm()
+            .get_http_authentication_config(&self.plugin_context(), auth_name, values, model_id)
+            .await?)
+    }
+
+    async fn call_http_authentication_action(
+        &self,
+        auth_name: &str,
+        action_index: i32,
+        values: HashMap<String, JsonPrimitive>,
+        model_id: &str,
+    ) -> yaak_commands::Result<()> {
+        Ok(self
+            .pm()
+            .call_http_authentication_action(
+                &self.plugin_context(),
+                auth_name,
+                action_index,
+                values,
+                model_id,
+            )
+            .await?)
+    }
+
+    async fn import_data(&self, content: &str) -> yaak_commands::Result<ImportResponse> {
+        Ok(self.pm().import_data(&self.plugin_context(), content).await?)
+    }
+
+    async fn reload_plugins(&self, plugins: Vec<Plugin>) -> Vec<(String, String)> {
+        self.pm().initialize_all_plugins(plugins, &self.plugin_context()).await
     }
 
     async fn encrypt_secure_template(&self, template: &str) -> yaak_commands::Result<String> {
-        let plugin_manager = Arc::new((*self.window.state::<PluginManager>()).clone());
+        let plugin_manager = Arc::new((*self.pm()).clone());
         let encryption_manager = Arc::new(self.encryption_manager().clone());
         Ok(encrypt_secure_template_function(
             plugin_manager,
@@ -333,36 +449,36 @@ async fn cmd_import_url<R: Runtime>(ctx: ClientCtx<R>, req: CmdImportUrlReq) -> 
     Ok(crate::cmd_import_url(ctx.window.clone(), &req.url).await?)
 }
 
-async fn cmd_http_request_actions<R: Runtime>(ctx: ClientCtx<R>, _req: CmdHttpRequestActionsReq) -> Result<Vec<GetHttpRequestActionsResponse>> {
-    Ok(crate::cmd_http_request_actions(ctx.window.clone(), ctx.window.app_handle().state::<PluginManager>()).await?)
+async fn cmd_http_request_actions<R: Runtime>(ctx: ClientCtx<R>, req: CmdHttpRequestActionsReq) -> Result<Vec<GetHttpRequestActionsResponse>> {
+    Ok(yaak_commands::actions::cmd_http_request_actions(ctx, req).await?)
 }
 
-async fn cmd_websocket_request_actions<R: Runtime>(ctx: ClientCtx<R>, _req: CmdWebsocketRequestActionsReq) -> Result<Vec<GetWebsocketRequestActionsResponse>> {
-    Ok(crate::cmd_websocket_request_actions(ctx.window.clone(), ctx.window.app_handle().state::<PluginManager>()).await?)
+async fn cmd_websocket_request_actions<R: Runtime>(ctx: ClientCtx<R>, req: CmdWebsocketRequestActionsReq) -> Result<Vec<GetWebsocketRequestActionsResponse>> {
+    Ok(yaak_commands::actions::cmd_websocket_request_actions(ctx, req).await?)
 }
 
 async fn cmd_call_websocket_request_action<R: Runtime>(ctx: ClientCtx<R>, req: CmdCallWebsocketRequestActionReq) -> Result<()> {
-    Ok(crate::cmd_call_websocket_request_action(ctx.window.clone(), req.req, ctx.window.app_handle().state::<PluginManager>()).await?)
+    Ok(yaak_commands::actions::cmd_call_websocket_request_action(ctx, req).await?)
 }
 
-async fn cmd_workspace_actions<R: Runtime>(ctx: ClientCtx<R>, _req: CmdWorkspaceActionsReq) -> Result<Vec<GetWorkspaceActionsResponse>> {
-    Ok(crate::cmd_workspace_actions(ctx.window.clone(), ctx.window.app_handle().state::<PluginManager>()).await?)
+async fn cmd_workspace_actions<R: Runtime>(ctx: ClientCtx<R>, req: CmdWorkspaceActionsReq) -> Result<Vec<GetWorkspaceActionsResponse>> {
+    Ok(yaak_commands::actions::cmd_workspace_actions(ctx, req).await?)
 }
 
 async fn cmd_call_workspace_action<R: Runtime>(ctx: ClientCtx<R>, req: CmdCallWorkspaceActionReq) -> Result<()> {
-    Ok(crate::cmd_call_workspace_action(ctx.window.clone(), req.req, ctx.window.app_handle().state::<PluginManager>()).await?)
+    Ok(yaak_commands::actions::cmd_call_workspace_action(ctx, req).await?)
 }
 
-async fn cmd_folder_actions<R: Runtime>(ctx: ClientCtx<R>, _req: CmdFolderActionsReq) -> Result<Vec<GetFolderActionsResponse>> {
-    Ok(crate::cmd_folder_actions(ctx.window.clone(), ctx.window.app_handle().state::<PluginManager>()).await?)
+async fn cmd_folder_actions<R: Runtime>(ctx: ClientCtx<R>, req: CmdFolderActionsReq) -> Result<Vec<GetFolderActionsResponse>> {
+    Ok(yaak_commands::actions::cmd_folder_actions(ctx, req).await?)
 }
 
 async fn cmd_call_folder_action<R: Runtime>(ctx: ClientCtx<R>, req: CmdCallFolderActionReq) -> Result<()> {
-    Ok(crate::cmd_call_folder_action(ctx.window.clone(), req.req, ctx.window.app_handle().state::<PluginManager>()).await?)
+    Ok(yaak_commands::actions::cmd_call_folder_action(ctx, req).await?)
 }
 
-async fn cmd_grpc_request_actions<R: Runtime>(ctx: ClientCtx<R>, _req: CmdGrpcRequestActionsReq) -> Result<Vec<GetGrpcRequestActionsResponse>> {
-    Ok(crate::cmd_grpc_request_actions(ctx.window.clone(), ctx.window.app_handle().state::<PluginManager>()).await?)
+async fn cmd_grpc_request_actions<R: Runtime>(ctx: ClientCtx<R>, req: CmdGrpcRequestActionsReq) -> Result<Vec<GetGrpcRequestActionsResponse>> {
+    Ok(yaak_commands::actions::cmd_grpc_request_actions(ctx, req).await?)
 }
 
 async fn cmd_template_function_summaries<R: Runtime>(ctx: ClientCtx<R>, req: CmdTemplateFunctionSummariesReq) -> Result<Vec<GetTemplateFunctionSummaryResponse>> {
@@ -373,28 +489,28 @@ async fn cmd_template_function_config<R: Runtime>(ctx: ClientCtx<R>, req: CmdTem
     Ok(yaak_commands::templates::cmd_template_function_config(ctx, req).await?)
 }
 
-async fn cmd_get_http_authentication_summaries<R: Runtime>(ctx: ClientCtx<R>, _req: CmdGetHttpAuthenticationSummariesReq) -> Result<Vec<GetHttpAuthenticationSummaryResponse>> {
-    Ok(crate::cmd_get_http_authentication_summaries(ctx.window.clone(), ctx.window.app_handle().state::<PluginManager>()).await?)
+async fn cmd_get_http_authentication_summaries<R: Runtime>(ctx: ClientCtx<R>, req: CmdGetHttpAuthenticationSummariesReq) -> Result<Vec<GetHttpAuthenticationSummaryResponse>> {
+    Ok(yaak_commands::auth::cmd_get_http_authentication_summaries(ctx, req).await?)
 }
 
 async fn cmd_get_http_authentication_config<R: Runtime>(ctx: ClientCtx<R>, req: CmdGetHttpAuthenticationConfigReq) -> Result<GetHttpAuthenticationConfigResponse> {
-    Ok(crate::cmd_get_http_authentication_config(ctx.window.clone(), ctx.window.app_handle().clone(), ctx.window.app_handle().state::<PluginManager>(), ctx.window.app_handle().state::<EncryptionManager>(), &req.auth_name, req.values, req.model, req.environment_id.as_deref()).await?)
+    Ok(yaak_commands::auth::cmd_get_http_authentication_config(ctx, req).await?)
 }
 
 async fn cmd_call_http_request_action<R: Runtime>(ctx: ClientCtx<R>, req: CmdCallHttpRequestActionReq) -> Result<()> {
-    Ok(crate::cmd_call_http_request_action(ctx.window.clone(), req.req, ctx.window.app_handle().state::<PluginManager>()).await?)
+    Ok(yaak_commands::actions::cmd_call_http_request_action(ctx, req).await?)
 }
 
 async fn cmd_call_grpc_request_action<R: Runtime>(ctx: ClientCtx<R>, req: CmdCallGrpcRequestActionReq) -> Result<()> {
-    Ok(crate::cmd_call_grpc_request_action(ctx.window.clone(), req.req, ctx.window.app_handle().state::<PluginManager>()).await?)
+    Ok(yaak_commands::actions::cmd_call_grpc_request_action(ctx, req).await?)
 }
 
 async fn cmd_call_http_authentication_action<R: Runtime>(ctx: ClientCtx<R>, req: CmdCallHttpAuthenticationActionReq) -> Result<()> {
-    Ok(crate::cmd_call_http_authentication_action(ctx.window.clone(), ctx.window.app_handle().clone(), ctx.window.app_handle().state::<PluginManager>(), ctx.window.app_handle().state::<EncryptionManager>(), &req.auth_name, req.action_index, req.values, req.model, req.environment_id.as_deref()).await?)
+    Ok(yaak_commands::auth::cmd_call_http_authentication_action(ctx, req).await?)
 }
 
 async fn cmd_curl_to_request<R: Runtime>(ctx: ClientCtx<R>, req: CmdCurlToRequestReq) -> Result<HttpRequest> {
-    Ok(crate::cmd_curl_to_request(ctx.window.clone(), &req.command, ctx.window.app_handle().state::<PluginManager>(), &req.workspace_id).await?)
+    Ok(yaak_commands::actions::cmd_curl_to_request(ctx, req).await?)
 }
 
 async fn cmd_export_data<R: Runtime>(ctx: ClientCtx<R>, req: CmdExportDataReq) -> Result<()> {
@@ -413,8 +529,8 @@ async fn cmd_send_http_request<R: Runtime>(ctx: ClientCtx<R>, req: CmdSendHttpRe
     Ok(crate::cmd_send_http_request(ctx.window.app_handle().clone(), ctx.window.clone(), req.environment_id.as_deref(), req.cookie_jar_id.as_deref(), req.request_id).await?)
 }
 
-async fn cmd_reload_plugins<R: Runtime>(ctx: ClientCtx<R>, _req: CmdReloadPluginsReq) -> Result<Vec<(String, String)>> {
-    Ok(crate::cmd_reload_plugins(ctx.window.app_handle().clone(), ctx.window.clone(), ctx.window.app_handle().state::<PluginManager>()).await?)
+async fn cmd_reload_plugins<R: Runtime>(ctx: ClientCtx<R>, req: CmdReloadPluginsReq) -> Result<Vec<(String, String)>> {
+    Ok(yaak_commands::actions::cmd_reload_plugins(ctx, req).await?)
 }
 
 async fn cmd_plugin_info<R: Runtime>(ctx: ClientCtx<R>, req: CmdPluginInfoReq) -> Result<PluginMetadata> {

--- a/crates-tauri/yaak-app-client/src/ws_ext.rs
+++ b/crates-tauri/yaak-app-client/src/ws_ext.rs
@@ -18,7 +18,7 @@ use yaak_http::cookies::CookieStore;
 use yaak_http::path_placeholders::apply_path_placeholders;
 use yaak_models::models::{
     HttpResponseHeader, WebsocketConnection, WebsocketConnectionState, WebsocketEvent,
-    WebsocketEventType, WebsocketRequest,
+    WebsocketEventType,
 };
 use yaak_models::util::UpdateSource;
 use yaak_plugins::events::{CallHttpAuthenticationRequest, HttpHeader, RenderPurpose};
@@ -27,6 +27,7 @@ use yaak_plugins::template_callback::PluginTemplateCallback;
 use yaak_templates::strip_json_comments::maybe_strip_json_comments;
 use yaak_templates::{RenderErrorBehavior, RenderOptions};
 use yaak_tls::find_client_certificate;
+use yaak_commands::resolve::resolve_websocket_request;
 use yaak_ws::{WebsocketManager, render_websocket_request};
 
 pub async fn cmd_ws_send<R: Runtime>(
@@ -75,7 +76,7 @@ async fn send_websocket_message<R: Runtime>(
         environment_id,
     )?;
     let (resolved_request, _auth_context_id) =
-        resolve_websocket_request(&window, &unrendered_request)?;
+        resolve_websocket_request(&window.db(), &unrendered_request)?;
     let plugin_manager = Arc::new((*app_handle.state::<PluginManager>()).clone());
     let encryption_manager = Arc::new((*app_handle.state::<EncryptionManager>()).clone());
     let request = render_websocket_request(
@@ -154,7 +155,7 @@ pub async fn cmd_ws_connect<R: Runtime>(
         app_handle.db().resolve_settings_for_websocket_request(&unrendered_request)?;
     let settings = app_handle.db().get_settings();
     let (resolved_request, auth_context_id) =
-        resolve_websocket_request(&window, &unrendered_request)?;
+        resolve_websocket_request(&window.db(), &unrendered_request)?;
     let plugin_manager = Arc::new((*app_handle.state::<PluginManager>()).clone());
     let encryption_manager = Arc::new((*app_handle.state::<EncryptionManager>()).clone());
     let request = render_websocket_request(
@@ -454,23 +455,6 @@ pub async fn cmd_ws_connect<R: Runtime>(
     Ok(connection)
 }
 
-/// Resolve inherited authentication and headers for a websocket request
-fn resolve_websocket_request<R: Runtime>(
-    window: &WebviewWindow<R>,
-    request: &WebsocketRequest,
-) -> Result<(WebsocketRequest, String)> {
-    let mut new_request = request.clone();
-
-    let (authentication_type, authentication, authentication_context_id) =
-        window.db().resolve_auth_for_websocket_request(request)?;
-    new_request.authentication_type = authentication_type;
-    new_request.authentication = authentication;
-
-    let headers = window.db().resolve_headers_for_websocket_request(request)?;
-    new_request.headers = headers;
-
-    Ok((new_request, authentication_context_id))
-}
 
 /// Convert WS URL to HTTP URL for cookie filtering
 /// WebSocket upgrade requests are HTTP requests initially, so HttpOnly cookies should apply

--- a/crates/yaak-commands/Cargo.toml
+++ b/crates/yaak-commands/Cargo.toml
@@ -6,10 +6,8 @@ authors = ["Gregory Schier"]
 publish = false
 
 [dependencies]
-log = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["rt"] }
 yaak = { workspace = true }
 yaak-core = { workspace = true }
 yaak-crypto = { workspace = true }

--- a/crates/yaak-commands/src/actions.rs
+++ b/crates/yaak-commands/src/actions.rs
@@ -1,0 +1,157 @@
+//! The actions plugins contribute to the UI, and the calls that run them.
+//!
+//! Listing is a plain question for the plugin runtime. Calling is not: the
+//! frontend sends back the model it was showing, and a plugin must act on what
+//! that model *actually is* — re-read from the database, with inheritance
+//! resolved — not on a snapshot the UI has been holding. That re-reading is the
+//! work these handlers do.
+
+use crate::error::{Error, Result};
+use crate::host::PluginHost;
+use crate::resolve::{resolve_grpc_request, resolve_http_request};
+use yaak_models::models::HttpRequest;
+use yaak_plugins::events::{
+    CallFolderActionArgs, CallFolderActionRequest, CallGrpcRequestActionArgs,
+    CallGrpcRequestActionRequest, CallHttpRequestActionArgs, CallHttpRequestActionRequest,
+    CallWebsocketRequestActionArgs, CallWebsocketRequestActionRequest, CallWorkspaceActionArgs,
+    CallWorkspaceActionRequest, GetFolderActionsResponse, GetGrpcRequestActionsResponse,
+    GetHttpRequestActionsResponse, GetWebsocketRequestActionsResponse, GetWorkspaceActionsResponse,
+};
+use yaak_rpc_schema::*;
+
+// -- Listing --
+
+pub async fn cmd_http_request_actions<H: PluginHost>(
+    host: H,
+    _req: CmdHttpRequestActionsReq,
+) -> Result<Vec<GetHttpRequestActionsResponse>> {
+    host.http_request_actions().await
+}
+
+pub async fn cmd_websocket_request_actions<H: PluginHost>(
+    host: H,
+    _req: CmdWebsocketRequestActionsReq,
+) -> Result<Vec<GetWebsocketRequestActionsResponse>> {
+    host.websocket_request_actions().await
+}
+
+pub async fn cmd_grpc_request_actions<H: PluginHost>(
+    host: H,
+    _req: CmdGrpcRequestActionsReq,
+) -> Result<Vec<GetGrpcRequestActionsResponse>> {
+    host.grpc_request_actions().await
+}
+
+pub async fn cmd_workspace_actions<H: PluginHost>(
+    host: H,
+    _req: CmdWorkspaceActionsReq,
+) -> Result<Vec<GetWorkspaceActionsResponse>> {
+    host.workspace_actions().await
+}
+
+pub async fn cmd_folder_actions<H: PluginHost>(
+    host: H,
+    _req: CmdFolderActionsReq,
+) -> Result<Vec<GetFolderActionsResponse>> {
+    host.folder_actions().await
+}
+
+// -- Calling --
+
+pub async fn cmd_call_http_request_action<H: PluginHost>(
+    host: H,
+    req: CmdCallHttpRequestActionReq,
+) -> Result<()> {
+    let inner = req.req;
+    let http_request = resolve_http_request(&host.db(), &inner.args.http_request)?.0;
+    host.call_http_request_action(CallHttpRequestActionRequest {
+        args: CallHttpRequestActionArgs { http_request, ..inner.args },
+        ..inner
+    })
+    .await
+}
+
+pub async fn cmd_call_grpc_request_action<H: PluginHost>(
+    host: H,
+    req: CmdCallGrpcRequestActionReq,
+) -> Result<()> {
+    let inner = req.req;
+    let grpc_request = resolve_grpc_request(&host.db(), &inner.args.grpc_request)?.0;
+    host.call_grpc_request_action(CallGrpcRequestActionRequest {
+        args: CallGrpcRequestActionArgs { grpc_request, ..inner.args },
+        ..inner
+    })
+    .await
+}
+
+pub async fn cmd_call_websocket_request_action<H: PluginHost>(
+    host: H,
+    req: CmdCallWebsocketRequestActionReq,
+) -> Result<()> {
+    let inner = req.req;
+    let websocket_request = host.db().get_websocket_request(&inner.args.websocket_request.id)?;
+    host.call_websocket_request_action(CallWebsocketRequestActionRequest {
+        args: CallWebsocketRequestActionArgs { websocket_request },
+        ..inner
+    })
+    .await
+}
+
+pub async fn cmd_call_workspace_action<H: PluginHost>(
+    host: H,
+    req: CmdCallWorkspaceActionReq,
+) -> Result<()> {
+    let inner = req.req;
+    let workspace = host.db().get_workspace(&inner.args.workspace.id)?;
+    host.call_workspace_action(CallWorkspaceActionRequest {
+        args: CallWorkspaceActionArgs { workspace },
+        ..inner
+    })
+    .await
+}
+
+pub async fn cmd_call_folder_action<H: PluginHost>(
+    host: H,
+    req: CmdCallFolderActionReq,
+) -> Result<()> {
+    let inner = req.req;
+    let folder = host.db().get_folder(&inner.args.folder.id)?;
+    host.call_folder_action(CallFolderActionRequest {
+        args: CallFolderActionArgs { folder },
+        ..inner
+    })
+    .await
+}
+
+// -- Other things the plugin runtime does --
+
+/// Turn a `curl` command line into an unsaved request, by handing it to the
+/// same importer plugins that read files.
+pub async fn cmd_curl_to_request<H: PluginHost>(
+    host: H,
+    req: CmdCurlToRequestReq,
+) -> Result<HttpRequest> {
+    let imported = host.import_data(&req.command).await?;
+
+    let request = imported
+        .resources
+        .http_requests
+        .first()
+        .ok_or_else(|| Error::Generic("No curl command found".to_string()))?;
+
+    // Belongs to the workspace the user is importing into, and is not saved
+    // until they say so — hence the blank id.
+    let mut request = request.clone();
+    request.workspace_id = req.workspace_id;
+    request.id = String::new();
+    Ok(request)
+}
+
+/// Restart every plugin, returning whatever failed to come back up.
+pub async fn cmd_reload_plugins<H: PluginHost>(
+    host: H,
+    _req: CmdReloadPluginsReq,
+) -> Result<Vec<(String, String)>> {
+    let plugins = host.db().list_plugins()?;
+    Ok(host.reload_plugins(plugins).await)
+}

--- a/crates/yaak-commands/src/actions.rs
+++ b/crates/yaak-commands/src/actions.rs
@@ -65,7 +65,7 @@ pub async fn cmd_call_http_request_action<H: PluginHost>(
     let inner = req.req;
     let http_request = resolve_http_request(&host.db(), &inner.args.http_request)?.0;
     host.call_http_request_action(CallHttpRequestActionRequest {
-        args: CallHttpRequestActionArgs { http_request, ..inner.args },
+        args: CallHttpRequestActionArgs { http_request },
         ..inner
     })
     .await

--- a/crates/yaak-commands/src/auth.rs
+++ b/crates/yaak-commands/src/auth.rs
@@ -41,7 +41,7 @@ pub async fn cmd_get_http_authentication_config<H: PluginHost>(
     )
     .await?;
 
-    host.http_authentication_config(&req.auth_name, values, &req.model.id()).await
+    host.http_authentication_config(&req.auth_name, values, req.model.id()).await
 }
 
 pub async fn cmd_call_http_authentication_action<H: PluginHost>(
@@ -60,7 +60,7 @@ pub async fn cmd_call_http_authentication_action<H: PluginHost>(
     )
     .await?;
 
-    host.call_http_authentication_action(&req.auth_name, req.action_index, values, &req.model.id())
+    host.call_http_authentication_action(&req.auth_name, req.action_index, values, req.model.id())
         .await
 }
 

--- a/crates/yaak-commands/src/auth.rs
+++ b/crates/yaak-commands/src/auth.rs
@@ -1,0 +1,102 @@
+//! Authentication config forms and their actions.
+//!
+//! Both commands here do the same preparation: the frontend sends the model
+//! whose auth is being edited plus the values currently in the form, and those
+//! values may contain templates. They have to be rendered against the model's
+//! own environment chain before a plugin sees them, or an auth plugin receives
+//! `${[ api_key ]}` where it expected a key.
+
+use crate::error::{Error, Result};
+use crate::host::PluginHost;
+use crate::render::render_json_value;
+use std::collections::HashMap;
+use yaak_models::models::AnyModel;
+use yaak_plugins::events::{
+    GetHttpAuthenticationConfigResponse, GetHttpAuthenticationSummaryResponse, JsonPrimitive,
+    RenderPurpose,
+};
+use yaak_rpc_schema::*;
+use yaak_templates::RenderOptions;
+
+pub async fn cmd_get_http_authentication_summaries<H: PluginHost>(
+    host: H,
+    _req: CmdGetHttpAuthenticationSummariesReq,
+) -> Result<Vec<GetHttpAuthenticationSummaryResponse>> {
+    host.http_authentication_summaries().await
+}
+
+pub async fn cmd_get_http_authentication_config<H: PluginHost>(
+    host: H,
+    req: CmdGetHttpAuthenticationConfigReq,
+) -> Result<GetHttpAuthenticationConfigResponse> {
+    // A config form is being displayed, so a template that cannot resolve
+    // should show as blank rather than refuse to open the form.
+    let values = render_auth_values(
+        &host,
+        &req.model,
+        req.environment_id.as_deref(),
+        req.values,
+        RenderPurpose::Preview,
+        &RenderOptions::return_empty(),
+    )
+    .await?;
+
+    host.http_authentication_config(&req.auth_name, values, &req.model.id()).await
+}
+
+pub async fn cmd_call_http_authentication_action<H: PluginHost>(
+    host: H,
+    req: CmdCallHttpAuthenticationActionReq,
+) -> Result<()> {
+    // An action actually uses these values, so an unresolvable template is an
+    // error rather than an empty string that would silently authenticate wrong.
+    let values = render_auth_values(
+        &host,
+        &req.model,
+        req.environment_id.as_deref(),
+        req.values,
+        RenderPurpose::Send,
+        &RenderOptions::throw(),
+    )
+    .await?;
+
+    host.call_http_authentication_action(&req.auth_name, req.action_index, values, &req.model.id())
+        .await
+}
+
+/// Render the form's values against the environment chain the model sits in.
+///
+/// The chain depends on where the model lives — a request inherits through its
+/// folder, a workspace has only its own — so the model is what decides which
+/// variables are in scope.
+async fn render_auth_values<H: PluginHost>(
+    host: &H,
+    model: &AnyModel,
+    environment_id: Option<&str>,
+    values: HashMap<String, JsonPrimitive>,
+    purpose: RenderPurpose,
+    options: &RenderOptions,
+) -> Result<HashMap<String, JsonPrimitive>> {
+    let (workspace_id, folder_id) = match model {
+        AnyModel::HttpRequest(r) => (r.workspace_id.clone(), r.folder_id.clone()),
+        AnyModel::GrpcRequest(r) => (r.workspace_id.clone(), r.folder_id.clone()),
+        AnyModel::WebsocketRequest(r) => (r.workspace_id.clone(), r.folder_id.clone()),
+        AnyModel::Folder(f) => (f.workspace_id.clone(), f.folder_id.clone()),
+        AnyModel::Workspace(w) => (w.id.clone(), None),
+        other => {
+            return Err(Error::Generic(format!(
+                "Cannot resolve authentication for a {}",
+                other.model()
+            )));
+        }
+    };
+
+    let environment_chain =
+        host.db().resolve_environments(&workspace_id, folder_id.as_deref(), environment_id)?;
+
+    let cb = host.template_callback(purpose);
+    let rendered =
+        render_json_value(serde_json::to_value(&values)?, environment_chain, &cb, options).await?;
+
+    Ok(serde_json::from_value(rendered)?)
+}

--- a/crates/yaak-commands/src/host.rs
+++ b/crates/yaak-commands/src/host.rs
@@ -23,8 +23,13 @@ use yaak_models::models::Plugin;
 use yaak_models::query_manager::QueryManager;
 use yaak_models::util::UpdateSource;
 use yaak_plugins::events::{
+    CallFolderActionRequest, CallGrpcRequestActionRequest, CallHttpRequestActionRequest,
+    CallWebsocketRequestActionRequest, CallWorkspaceActionRequest, GetFolderActionsResponse,
+    GetGrpcRequestActionsResponse, GetHttpAuthenticationConfigResponse,
+    GetHttpAuthenticationSummaryResponse, GetHttpRequestActionsResponse,
     GetTemplateFunctionConfigResponse, GetTemplateFunctionSummaryResponse, GetThemesResponse,
-    JsonPrimitive, PluginContext, RenderPurpose,
+    GetWebsocketRequestActionsResponse, GetWorkspaceActionsResponse, ImportResponse, JsonPrimitive,
+    PluginContext, RenderPurpose,
 };
 use yaak_plugins::plugin_meta::PluginMetadata;
 use yaak_templates::TemplateCallback;
@@ -134,6 +139,77 @@ pub trait PluginHost: Host {
 
     /// Themes contributed by plugins.
     fn themes(&self) -> impl Future<Output = crate::Result<Vec<GetThemesResponse>>>;
+
+    // -- Actions plugins contribute to the UI --
+
+    fn http_request_actions(
+        &self,
+    ) -> impl Future<Output = crate::Result<Vec<GetHttpRequestActionsResponse>>>;
+    fn websocket_request_actions(
+        &self,
+    ) -> impl Future<Output = crate::Result<Vec<GetWebsocketRequestActionsResponse>>>;
+    fn grpc_request_actions(
+        &self,
+    ) -> impl Future<Output = crate::Result<Vec<GetGrpcRequestActionsResponse>>>;
+    fn workspace_actions(
+        &self,
+    ) -> impl Future<Output = crate::Result<Vec<GetWorkspaceActionsResponse>>>;
+    fn folder_actions(&self) -> impl Future<Output = crate::Result<Vec<GetFolderActionsResponse>>>;
+
+    /// Running an action. The request in each of these has already been
+    /// re-read and had its inheritance resolved by the handler; a host must
+    /// pass it through untouched.
+    fn call_http_request_action(
+        &self,
+        req: CallHttpRequestActionRequest,
+    ) -> impl Future<Output = crate::Result<()>>;
+    fn call_grpc_request_action(
+        &self,
+        req: CallGrpcRequestActionRequest,
+    ) -> impl Future<Output = crate::Result<()>>;
+    fn call_websocket_request_action(
+        &self,
+        req: CallWebsocketRequestActionRequest,
+    ) -> impl Future<Output = crate::Result<()>>;
+    fn call_workspace_action(
+        &self,
+        req: CallWorkspaceActionRequest,
+    ) -> impl Future<Output = crate::Result<()>>;
+    fn call_folder_action(
+        &self,
+        req: CallFolderActionRequest,
+    ) -> impl Future<Output = crate::Result<()>>;
+
+    // -- Authentication --
+
+    fn http_authentication_summaries(
+        &self,
+    ) -> impl Future<Output = crate::Result<Vec<GetHttpAuthenticationSummaryResponse>>>;
+
+    /// The form an auth plugin wants to show. `values` arrive already rendered.
+    fn http_authentication_config(
+        &self,
+        auth_name: &str,
+        values: HashMap<String, JsonPrimitive>,
+        model_id: &str,
+    ) -> impl Future<Output = crate::Result<GetHttpAuthenticationConfigResponse>>;
+
+    fn call_http_authentication_action(
+        &self,
+        auth_name: &str,
+        action_index: i32,
+        values: HashMap<String, JsonPrimitive>,
+        model_id: &str,
+    ) -> impl Future<Output = crate::Result<()>>;
+
+    // -- The importers, and the runtime itself --
+
+    /// Hand arbitrary text to the importer plugins and take what they make of
+    /// it. Used for files, URLs and pasted `curl` commands alike.
+    fn import_data(&self, content: &str) -> impl Future<Output = crate::Result<ImportResponse>>;
+
+    /// Restart every plugin, returning `(plugin, error)` for those that failed.
+    fn reload_plugins(&self, plugins: Vec<Plugin>) -> impl Future<Output = Vec<(String, String)>>;
 
     /// Re-encrypt the `secure(...)` values in a template.
     ///

--- a/crates/yaak-commands/src/lib.rs
+++ b/crates/yaak-commands/src/lib.rs
@@ -11,6 +11,8 @@
 //! host-specific types; the ones that stay behind are the ones only a desktop
 //! can serve (native windows, the updater, dialogs) or that still lean on it.
 
+pub mod actions;
+pub mod auth;
 pub mod data;
 pub mod encryption;
 pub mod error;
@@ -18,6 +20,7 @@ pub mod host;
 pub mod models;
 pub mod plugins;
 pub mod render;
+pub mod resolve;
 pub mod responses;
 pub mod templates;
 

--- a/crates/yaak-commands/src/resolve.rs
+++ b/crates/yaak-commands/src/resolve.rs
@@ -1,0 +1,56 @@
+//! Filling in what a request inherits from its folders and workspace.
+//!
+//! A request stored in the database records only what is set *on it*;
+//! authentication and headers can come from any ancestor. Anything that acts on
+//! a request as the user sees it — sending it, handing it to a plugin — has to
+//! resolve that chain first, which is why this is shared rather than living
+//! next to any one caller.
+
+use crate::error::Result;
+use yaak_models::client_db::ClientDb;
+use yaak_models::models::{GrpcRequest, HttpRequest, WebsocketRequest};
+
+/// The request with inherited auth and headers filled in, plus the id of the
+/// model the authentication was inherited *from* — plugins key their token
+/// caches on it, so it must be the ancestor's id and not the request's.
+pub fn resolve_http_request(db: &ClientDb, request: &HttpRequest) -> Result<(HttpRequest, String)> {
+    let mut new_request = request.clone();
+
+    let (authentication_type, authentication, authentication_context_id) =
+        db.resolve_auth_for_http_request(request)?;
+    new_request.authentication_type = authentication_type;
+    new_request.authentication = authentication;
+
+    new_request.headers = db.resolve_headers_for_http_request(request)?;
+
+    Ok((new_request, authentication_context_id))
+}
+
+pub fn resolve_grpc_request(db: &ClientDb, request: &GrpcRequest) -> Result<(GrpcRequest, String)> {
+    let mut new_request = request.clone();
+
+    let (authentication_type, authentication, authentication_context_id) =
+        db.resolve_auth_for_grpc_request(request)?;
+    new_request.authentication_type = authentication_type;
+    new_request.authentication = authentication;
+
+    new_request.metadata = db.resolve_metadata_for_grpc_request(request)?;
+
+    Ok((new_request, authentication_context_id))
+}
+
+pub fn resolve_websocket_request(
+    db: &ClientDb,
+    request: &WebsocketRequest,
+) -> Result<(WebsocketRequest, String)> {
+    let mut new_request = request.clone();
+
+    let (authentication_type, authentication, authentication_context_id) =
+        db.resolve_auth_for_websocket_request(request)?;
+    new_request.authentication_type = authentication_type;
+    new_request.authentication = authentication;
+
+    new_request.headers = db.resolve_headers_for_websocket_request(request)?;
+
+    Ok((new_request, authentication_context_id))
+}

--- a/crates/yaak-commands/src/templates.rs
+++ b/crates/yaak-commands/src/templates.rs
@@ -56,7 +56,7 @@ pub async fn cmd_template_function_config<H: PluginHost>(
     host: H,
     req: CmdTemplateFunctionConfigReq,
 ) -> Result<GetTemplateFunctionConfigResponse> {
-    host.template_function_config(&req.function_name, req.values, &req.model.id()).await
+    host.template_function_config(&req.function_name, req.values, req.model.id()).await
 }
 
 pub async fn cmd_get_themes<H: PluginHost>(

--- a/crates/yaak-commands/tests/test_host.rs
+++ b/crates/yaak-commands/tests/test_host.rs
@@ -8,10 +8,12 @@
 //! `PluginHost` too, without one, which is only possible because that trait
 //! names operations rather than handing back a manager.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
+use yaak_commands::auth::cmd_get_http_authentication_config;
 use yaak_commands::models::{
     cmd_default_headers, cmd_get_workspace_meta, models_delete, models_upsert,
     models_workspace_models,
@@ -25,8 +27,13 @@ use yaak_models::models::{AnyModel, Environment, EnvironmentVariable, Plugin, Wo
 use yaak_models::query_manager::QueryManager;
 use yaak_models::util::{ModelPayload, UpdateSource};
 use yaak_plugins::events::{
+    CallFolderActionRequest, CallGrpcRequestActionRequest, CallHttpRequestActionRequest,
+    CallWebsocketRequestActionRequest, CallWorkspaceActionRequest, GetFolderActionsResponse,
+    GetGrpcRequestActionsResponse, GetHttpAuthenticationConfigResponse,
+    GetHttpAuthenticationSummaryResponse, GetHttpRequestActionsResponse,
     GetTemplateFunctionConfigResponse, GetTemplateFunctionSummaryResponse, GetThemesResponse,
-    JsonPrimitive, RenderPurpose,
+    GetWebsocketRequestActionsResponse, GetWorkspaceActionsResponse, ImportResponse, JsonPrimitive,
+    RenderPurpose,
 };
 use yaak_plugins::plugin_meta::PluginMetadata;
 use yaak_rpc_schema::{
@@ -162,6 +169,9 @@ async fn host_free_handlers_need_no_state() {
 #[derive(Clone)]
 struct SingleThreadedHost {
     inner: Rc<Inner>,
+    /// The values the last auth-config call arrived with, so a test can check
+    /// they were rendered before the host ever saw them.
+    auth_values: Rc<RefCell<Option<HashMap<String, JsonPrimitive>>>>,
 }
 
 impl Host for SingleThreadedHost {
@@ -260,12 +270,113 @@ impl PluginHost for SingleThreadedHost {
     async fn themes(&self) -> yaak_commands::Result<Vec<GetThemesResponse>> {
         Ok(Vec::new())
     }
+
+    // No plugins, so nothing contributes actions and nothing can run one.
+
+    async fn http_request_actions(
+        &self,
+    ) -> yaak_commands::Result<Vec<GetHttpRequestActionsResponse>> {
+        Ok(Vec::new())
+    }
+
+    async fn websocket_request_actions(
+        &self,
+    ) -> yaak_commands::Result<Vec<GetWebsocketRequestActionsResponse>> {
+        Ok(Vec::new())
+    }
+
+    async fn grpc_request_actions(
+        &self,
+    ) -> yaak_commands::Result<Vec<GetGrpcRequestActionsResponse>> {
+        Ok(Vec::new())
+    }
+
+    async fn workspace_actions(&self) -> yaak_commands::Result<Vec<GetWorkspaceActionsResponse>> {
+        Ok(Vec::new())
+    }
+
+    async fn folder_actions(&self) -> yaak_commands::Result<Vec<GetFolderActionsResponse>> {
+        Ok(Vec::new())
+    }
+
+    async fn call_http_request_action(
+        &self,
+        _req: CallHttpRequestActionRequest,
+    ) -> yaak_commands::Result<()> {
+        Err(no_plugins())
+    }
+
+    async fn call_grpc_request_action(
+        &self,
+        _req: CallGrpcRequestActionRequest,
+    ) -> yaak_commands::Result<()> {
+        Err(no_plugins())
+    }
+
+    async fn call_websocket_request_action(
+        &self,
+        _req: CallWebsocketRequestActionRequest,
+    ) -> yaak_commands::Result<()> {
+        Err(no_plugins())
+    }
+
+    async fn call_workspace_action(
+        &self,
+        _req: CallWorkspaceActionRequest,
+    ) -> yaak_commands::Result<()> {
+        Err(no_plugins())
+    }
+
+    async fn call_folder_action(&self, _req: CallFolderActionRequest) -> yaak_commands::Result<()> {
+        Err(no_plugins())
+    }
+
+    async fn http_authentication_summaries(
+        &self,
+    ) -> yaak_commands::Result<Vec<GetHttpAuthenticationSummaryResponse>> {
+        Ok(Vec::new())
+    }
+
+    async fn http_authentication_config(
+        &self,
+        _auth_name: &str,
+        values: HashMap<String, JsonPrimitive>,
+        _model_id: &str,
+    ) -> yaak_commands::Result<GetHttpAuthenticationConfigResponse> {
+        *self.auth_values.borrow_mut() = Some(values);
+        Err(no_plugins())
+    }
+
+    async fn call_http_authentication_action(
+        &self,
+        _auth_name: &str,
+        _action_index: i32,
+        _values: HashMap<String, JsonPrimitive>,
+        _model_id: &str,
+    ) -> yaak_commands::Result<()> {
+        Err(no_plugins())
+    }
+
+    async fn import_data(&self, _content: &str) -> yaak_commands::Result<ImportResponse> {
+        Err(no_plugins())
+    }
+
+    async fn reload_plugins(&self, _plugins: Vec<Plugin>) -> Vec<(String, String)> {
+        Vec::new()
+    }
+}
+
+fn no_plugins() -> yaak_commands::Error {
+    yaak_commands::Error::Generic("no plugin runtime on this host".into())
 }
 
 #[tokio::test]
 async fn a_single_threaded_host_can_implement_the_trait() {
     let TestHost { inner } = TestHost::new();
-    let host = SingleThreadedHost { inner: Rc::new(Arc::into_inner(inner).expect("sole owner")) };
+    let host = SingleThreadedHost {
+        inner: Rc::new(Arc::into_inner(inner).expect("sole owner")),
+        auth_values: Rc::new(RefCell::new(None)),
+    };
 
     let workspace = Workspace { name: "From one thread".to_string(), ..Default::default() };
     let id = models_upsert(host.clone(), ModelsUpsertReq { model: AnyModel::Workspace(workspace) })
@@ -293,7 +404,6 @@ async fn a_single_threaded_host_can_implement_the_trait() {
             &Environment {
                 workspace_id: id.clone(),
                 name: "Test env".to_string(),
-                base: true,
                 variables: vec![EnvironmentVariable {
                     enabled: true,
                     name: "greeting".to_string(),
@@ -327,4 +437,65 @@ async fn a_single_threaded_host_can_implement_the_trait() {
         .await
         .expect("delete");
     assert_eq!(deleted, id);
+}
+
+/// Auth form values may contain templates, and a plugin must never see one
+/// unrendered. The rendering happens in the shared handler, so this checks the
+/// host received a resolved value rather than `${[ ... ]}`.
+#[tokio::test]
+async fn auth_values_are_rendered_before_the_host_sees_them() {
+    let TestHost { inner } = TestHost::new();
+    let host = SingleThreadedHost {
+        inner: Rc::new(Arc::into_inner(inner).expect("sole owner")),
+        auth_values: Rc::new(RefCell::new(None)),
+    };
+
+    let workspace = host
+        .db()
+        .upsert_workspace(
+            &Workspace { name: "Auth".to_string(), ..Default::default() },
+            &host.update_source(),
+        )
+        .expect("workspace");
+    host.db()
+        .upsert_environment(
+            &Environment {
+                workspace_id: workspace.id.clone(),
+                name: "Env".to_string(),
+                variables: vec![EnvironmentVariable {
+                    enabled: true,
+                    name: "token".to_string(),
+                    value: "s3cret".to_string(),
+                    id: None,
+                }],
+                ..Default::default()
+            },
+            &host.update_source(),
+        )
+        .expect("environment");
+    let environment =
+        host.db().list_environments_ensure_base(&workspace.id).expect("list").remove(0);
+
+    let mut values = HashMap::new();
+    values.insert("password".to_string(), JsonPrimitive::String("${[ token ]}".to_string()));
+
+    // The host refuses the call itself — it has no plugins — but only after the
+    // handler has rendered and handed over the values, which is what matters.
+    let _ = cmd_get_http_authentication_config(
+        host.clone(),
+        yaak_rpc_schema::CmdGetHttpAuthenticationConfigReq {
+            auth_name: "basic".to_string(),
+            values,
+            model: AnyModel::Workspace(workspace),
+            environment_id: Some(environment.id),
+        },
+    )
+    .await;
+
+    let seen = host.auth_values.borrow().clone().expect("the host should have been called");
+    assert!(
+        matches!(seen.get("password"), Some(JsonPrimitive::String(v)) if v == "s3cret"),
+        "the template should have been rendered before reaching the host, got {:?}",
+        seen.get("password"),
+    );
 }


### PR DESCRIPTION
Follows #559, finishing batch 2. Fifteen commands move: the ten action listings and calls, the three authentication commands, `cmd_curl_to_request`, and `cmd_reload_plugins`. Desktop `lib.rs` loses 283 lines.

Two things beyond a straight move:

**The auth duplication is gone.** `cmd_get_http_authentication_config` and `cmd_call_http_authentication_action` each carried the same ~30 lines — find the model's workspace and folder, resolve the environment chain, render the form values, convert back. That's one `render_auth_values` helper now, with the callers differing only in what a bad template should do: a config form shows blanks, an action refuses, because one is being displayed and the other is about to authenticate with the result.

**Three resolve helpers became one.** `resolve_http_request`, `resolve_grpc_request` and `resolve_websocket_request` were near-identical database reads in three different Tauri modules. They're in `yaak-commands/src/resolve.rs`, and the gRPC and WebSocket commands that haven't moved yet call the shared ones — so nothing forks while they wait.

`PluginHost` is 23 methods now. Large, but each is a distinct thing the frontend asks of the plugin runtime and each desktop impl is one line; a `ClientCtx::pm()` accessor keeps them reading as delegations.

`cmd_import_data` / `cmd_import_url` stay behind — a file read and an HTTP fetch around an already-shared importer. Moving them would mean inventing a host filesystem capability with one caller.

Verified: workspace and app build warning-free, tests pass, app boots and runs `cmd_workspace_actions` and `cmd_get_http_authentication_summaries`. A new test asserts a templated auth value reaches the host as `s3cret` rather than `${[ token ]}`, so it fails if that render is ever skipped.

Not exercised in the UI: the `call_*_action` paths, auth config/action, and `cmd_curl_to_request` — worth a click before merge, especially a plugin action and an auth form.
