### PR TITLE
Restore ubuntu-22.04 release runners; use clang-15 for the wasm build

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -26,19 +26,19 @@ jobs:
             os: "macos"
             runtime: "wry"
             targets: "x86_64-apple-darwin"
-          - platform: "ubuntu-24.04"
+          - platform: "ubuntu-22.04"
             args: '--config ./tauri.release.conf.json --config ''{"build":{"features":["updater","license","wry"]}}'''
             yaak_arch: "x64"
             os: "ubuntu"
             runtime: "wry"
             targets: ""
-          - platform: "ubuntu-24.04-arm"
+          - platform: "ubuntu-22.04-arm"
             args: '--config ./tauri.release.conf.json --config ''{"build":{"features":["updater","license","wry"]}}'''
             yaak_arch: "arm64"
             os: "ubuntu"
             runtime: "wry"
             targets: ""
-          - platform: "ubuntu-24.04"
+          - platform: "ubuntu-22.04"
             args: >-
               --bundles deb
               --config ./tauri.release.conf.json
@@ -47,7 +47,7 @@ jobs:
             os: "ubuntu"
             runtime: "cef"
             targets: ""
-          - platform: "ubuntu-24.04-arm"
+          - platform: "ubuntu-22.04-arm"
             args: >-
               --bundles deb
               --config ./tauri.release.conf.json
@@ -102,7 +102,13 @@ jobs:
         if: matrix.os == 'ubuntu'
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libnss3 patchelf xdg-utils
+          sudo apt-get install -y cmake ninja-build libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libnss3 patchelf xdg-utils clang-15 llvm-15
+          # crates/yaak-web compiles SQLite to wasm via sqlite-wasm-rs, whose C shim
+          # uses C23 [[noreturn]]. Ubuntu 22.04's default clang-14 rejects it; clang-15
+          # from the same repos accepts it. Only the wasm build uses this compiler, so
+          # the shipped binary keeps 22.04's glibc floor.
+          echo "CC_wasm32_unknown_unknown=/usr/bin/clang-15" >> "$GITHUB_ENV"
+          echo "AR_wasm32_unknown_unknown=/usr/bin/llvm-ar-15" >> "$GITHUB_ENV"
 
       - name: Install Protoc for plugin-runtime
         uses: arduino/setup-protoc@v3


### PR DESCRIPTION
0f434361a fixed the Linux release build by moving the runners to ubuntu-24.04, but that raised the shipped binary's glibc floor from 2.35 to 2.39, so new builds would stop launching on Ubuntu 22.04, Debian 12 and RHEL 9.

The actual need was narrower: `crates/yaak-web` compiles SQLite to wasm via sqlite-wasm-rs, whose C shim uses C23 `[[noreturn]]`, and 22.04's default clang-14 rejects it. clang-15 accepts it and ships in 22.04's own repos for both amd64 and arm64 (`15.0.7-0ubuntu0.22.04.3`), so this installs `clang-15 llvm-15` and points `CC_wasm32_unknown_unknown` / `AR_wasm32_unknown_unknown` at them. `build-wasm.cjs` already reads those vars first.

Only the wasm build uses the newer clang; the app's Rust toolchain and linker are unchanged, so the binary keeps 22.04's glibc floor. `ci.yml` is unaffected (it bootstraps on macos-latest only).

Not verifiable locally beyond a matching clang compiling the shim, so the beta.4 tag build is the end-to-end check.