### PR TITLE
Force text presentation for the Enter hotkey symbol

### DIFF
--- a/apps/yaak-client/hooks/useHotKey.ts
+++ b/apps/yaak-client/hooks/useHotKey.ts
@@ -333,7 +333,9 @@ export function formatHotkeyString(trigger: string): string[] {
       } else if (p === "Alt") {
         labelParts.push("⌥");
       } else if (p === "Enter") {
-        labelParts.push("↩");
+        // U+21A9 has an emoji presentation, which Chromium's font fallback picks
+        // (a blue glyph among monochrome ones). U+FE0E forces the text form.
+        labelParts.push("↩︎");
       } else if (p === "Tab") {
         labelParts.push("⇥");
       } else if (p === "Backspace") {


### PR DESCRIPTION
The Enter symbol in hotkey labels (`⌘↩`) rendered as a color emoji glyph in the browser build. U+21A9 has an emoji presentation, and the interface font stack ends with `Apple Color Emoji`, so Chromium falls through to it. U+FE0E forces the text form.

Desktop is unaffected either way — verified old and new render pixel-identically in WKWebView. `↩` is the only symbol in the map with an emoji presentation.